### PR TITLE
[janitor] github.com/epfl-idevelop → github.com/epfl-si

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
   WordPress @ EPFL: DevOps Boogaloo
 </h1>
 
-[![Build Status](https://travis-ci.org/epfl-idevelop/wp-ops.svg?branch=master)](https://travis-ci.org/epfl-idevelop/wp-ops)
+[![Build Status](https://travis-ci.org/epfl-si/wp-ops.svg?branch=master)](https://travis-ci.org/epfl-si/wp-ops)
 
 In this repository you will find:
 

--- a/ansible/inventory/wp-veritas/wp_veritas_inventory.py
+++ b/ansible/inventory/wp-veritas/wp_veritas_inventory.py
@@ -3,7 +3,7 @@
 # All rights reserved. ECOLE POLYTECHNIQUE FEDERALE DE LAUSANNE, Switzerland, VPSI, 2019
 #
 # Build an Ansible inventory from wp-veritas
-# this file is found in https://github.com/epfl-idevelop/wp-ops under
+# this file is found in https://github.com/epfl-si/wp-ops under
 # subdirectory ansible/tower/inventory_scripts
 #
 # Example invocation:

--- a/ansible/roles/awx-poc-vpsi/vars/main.yml
+++ b/ansible/roles/awx-poc-vpsi/vars/main.yml
@@ -3,7 +3,7 @@ awx_wpveritas_inventory_script_name: "Fetch wp-veritas sites"
 awx_wpveritas_inventory_script_path: "../../../inventory/wp-veritas/wp_veritas_inventory.py"
 
 awx_project_name: "WWP"
-awx_project_github_url: "https://github.com/epfl-idevelop/wp-ops"
+awx_project_github_url: "https://github.com/epfl-si/wp-ops"
 
 awx_wpveritas_inventory_script_name: "Fetch wp-veritas sites"
 awx_wpveritas_inventory_script_path: "../../../inventory/wp-veritas/wp_veritas_inventory.py"

--- a/ansible/roles/wordpress-instance/tasks/plugins.yml
+++ b/ansible/roles/wordpress-instance/tasks/plugins.yml
@@ -2,7 +2,7 @@
 ##
 ## ⚠ Until such time that we don't use the jahia2wp repository, the
 ## configuration herein duplicates the one at
-## https://github.com/epfl-idevelop/jahia2wp/blob/release2018/data/plugins/generic/config-lot1.yml
+## https://github.com/epfl-si/jahia2wp/blob/release2018/data/plugins/generic/config-lot1.yml
 ## (and ditto in the "release" branch as well).
 ## Please be sure to propagate your changes there as well.
 
@@ -32,8 +32,8 @@
       - symlinked
       - must-use
     from:
-      - https://github.com/epfl-idevelop/jahia2wp/blob/release2018/data/wp/wp-content/mu-plugins/epfl-custom-editor-menu
-      - https://github.com/epfl-idevelop/jahia2wp/blob/release2018/data/wp/wp-content/mu-plugins/EPFL_custom_editor_menu_loader.php
+      - https://github.com/epfl-si/jahia2wp/blob/release2018/data/wp/wp-content/mu-plugins/epfl-custom-editor-menu
+      - https://github.com/epfl-si/jahia2wp/blob/release2018/data/wp/wp-content/mu-plugins/EPFL_custom_editor_menu_loader.php
 
 
 - name: Blocks white-list (must-use plugin)
@@ -42,7 +42,7 @@
     state:
       - symlinked
       - must-use
-    from: https://github.com/epfl-idevelop/jahia2wp/blob/release2018/data/wp/wp-content/mu-plugins/EPFL_block_white_list.php
+    from: https://github.com/epfl-si/jahia2wp/blob/release2018/data/wp/wp-content/mu-plugins/EPFL_block_white_list.php
 
 - name: Disable comments (must-use plugin)
   wordpress_plugin:
@@ -50,7 +50,7 @@
     state:
       - symlinked
       - must-use
-    from: https://github.com/epfl-idevelop/jahia2wp/blob/release2018/data/wp/wp-content/mu-plugins/EPFL_disable_comments.php
+    from: https://github.com/epfl-si/jahia2wp/blob/release2018/data/wp/wp-content/mu-plugins/EPFL_disable_comments.php
 
 - name: Disable automatic updates (must-use plugin)
   wordpress_plugin:
@@ -58,7 +58,7 @@
     state:
       - symlinked
       - must-use
-    from: https://github.com/epfl-idevelop/jahia2wp/blob/release2018/data/wp/wp-content/mu-plugins/EPFL_disable_updates_automatic.php
+    from: https://github.com/epfl-si/jahia2wp/blob/release2018/data/wp/wp-content/mu-plugins/EPFL_disable_updates_automatic.php
 
 - name: Google Analytics hook (must-use plugin)
   wordpress_plugin:
@@ -66,13 +66,13 @@
     state:
       - symlinked
       - must-use
-    from: https://github.com/epfl-idevelop/jahia2wp/blob/release2018/data/wp/wp-content/mu-plugins/EPFL_google_analytics_hook.php
+    from: https://github.com/epfl-si/jahia2wp/blob/release2018/data/wp/wp-content/mu-plugins/EPFL_google_analytics_hook.php
 
 - name: Locked installs (must-use plugin)
   wordpress_plugin:
     name: EPFL_installs_locked
     state: '{{ ["symlinked", "must-use"] if wp_is_managed else "absent" }}'
-    from: https://github.com/epfl-idevelop/jahia2wp/blob/release2018/data/wp/wp-content/mu-plugins/EPFL_installs_locked.php
+    from: https://github.com/epfl-si/jahia2wp/blob/release2018/data/wp/wp-content/mu-plugins/EPFL_installs_locked.php
 
 - name: Jahia redirect tracker (must-use plugin)
   wordpress_plugin:
@@ -80,7 +80,7 @@
     state:
       - symlinked
       - must-use
-    from: https://github.com/epfl-idevelop/jahia2wp/blob/release2018/data/wp/wp-content/mu-plugins/EPFL_jahia_redirect.php
+    from: https://github.com/epfl-si/jahia2wp/blob/release2018/data/wp/wp-content/mu-plugins/EPFL_jahia_redirect.php
 
 - name: EPFL functions (must-use plugin)
   wordpress_plugin:
@@ -88,7 +88,7 @@
     state:
       - symlinked
       - must-use
-    from: https://github.com/epfl-idevelop/jahia2wp/blob/release2018/data/wp/wp-content/mu-plugins/epfl-functions.php
+    from: https://github.com/epfl-si/jahia2wp/blob/release2018/data/wp/wp-content/mu-plugins/epfl-functions.php
 
 - name: Quota (must-use plugin)
   wordpress_plugin:
@@ -97,8 +97,8 @@
       - symlinked
       - must-use
     from:
-      - https://github.com/epfl-idevelop/jahia2wp/tree/release2018/data/wp/wp-content/mu-plugins/epfl-quota
-      - https://github.com/epfl-idevelop/jahia2wp/blob/release2018/data/wp/wp-content/mu-plugins/EPFL_quota_loader.php
+      - https://github.com/epfl-si/jahia2wp/tree/release2018/data/wp/wp-content/mu-plugins/epfl-quota
+      - https://github.com/epfl-si/jahia2wp/blob/release2018/data/wp/wp-content/mu-plugins/EPFL_quota_loader.php
 
 - name: Stats (must-use plugin)
   wordpress_plugin:
@@ -107,8 +107,8 @@
       - symlinked
       - must-use
     from:
-      - https://github.com/epfl-idevelop/jahia2wp/tree/release2018/data/wp/wp-content/mu-plugins/epfl-stats
-      - https://github.com/epfl-idevelop/jahia2wp/blob/release2018/data/wp/wp-content/mu-plugins/EPFL_stats_loader.php
+      - https://github.com/epfl-si/jahia2wp/tree/release2018/data/wp/wp-content/mu-plugins/epfl-stats
+      - https://github.com/epfl-si/jahia2wp/blob/release2018/data/wp/wp-content/mu-plugins/EPFL_stats_loader.php
 
 ##################### "2018" plugins ###########################
 
@@ -205,7 +205,7 @@
     state:
       - symlinked
       - active
-    from: https://github.com/epfl-idevelop/jahia2wp/tree/release2018/data/wp/wp-content/plugins/cache-control
+    from: https://github.com/epfl-si/jahia2wp/tree/release2018/data/wp/wp-content/plugins/cache-control
 
 - name: Cache-Control options
   wordpress_option: "{{ item }}"
@@ -222,13 +222,13 @@
     state:
       - symlinked
       - active
-    from: https://github.com/epfl-idevelop/wp-plugin-epfl-settings
+    from: https://github.com/epfl-si/wp-plugin-epfl-settings
 
 - name: EPFL-Content-Filter plugin
   wordpress_plugin:
     name: EPFL-Content-Filter
     state: '{{ ["symlinked", "active"] if plugins_locked else "absent" }}'
-    from: https://github.com/epfl-idevelop/wp-plugin-epfl-content-filter
+    from: https://github.com/epfl-si/wp-plugin-epfl-content-filter
 
 # TODO: we are not quite sure anymore whether this plugin is useful.
 - name: SVG-support plugin
@@ -249,7 +249,7 @@
     state:
       - symlinked
       - active
-    from: https://github.com/epfl-idevelop/jahia2wp/tree/release2018/data/wp/wp-content/plugins/remote-content-shortcode
+    from: https://github.com/epfl-si/jahia2wp/tree/release2018/data/wp/wp-content/plugins/remote-content-shortcode
 
 - name: shortcode-ui plugin
   wordpress_plugin:
@@ -270,7 +270,7 @@
     name: epfl
     state: >-
       {{ "absent" if plugins_use_gutenberg else [ "symlinked", "active" ]  }}
-    from: https://github.com/epfl-idevelop/jahia2wp/tree/release2018/data/wp/wp-content/plugins/epfl
+    from: https://github.com/epfl-si/jahia2wp/tree/release2018/data/wp/wp-content/plugins/epfl
 
 
 - name: EPFL Gutenberg plugin
@@ -280,14 +280,14 @@
       - symlinked
       - >-
         {{ "active" if plugins_use_gutenberg else "inactive" }}
-    from: https://github.com/epfl-idevelop/wp-gutenberg-epfl
+    from: https://github.com/epfl-si/wp-gutenberg-epfl
 
 - name: EPFL Menus plugin
   wordpress_plugin:
     name: epfl-menus
     state: >-
         {{ "absent" if plugins_use_wp2010_plugins else [ "symlinked", "active" ] }}
-    from: https://github.com/epfl-idevelop/wp-plugin-epfl-menus
+    from: https://github.com/epfl-si/wp-plugin-epfl-menus
 
 - name: wp-media-folder plugin
   wordpress_plugin:
@@ -314,7 +314,7 @@
     state:
       - symlinked
       - active
-    from: https://github.com/epfl-idevelop/wp-plugin-epfl-404
+    from: https://github.com/epfl-si/wp-plugin-epfl-404
 
 - name: ewww-image-optimizer plugin
   wordpress_plugin:
@@ -334,7 +334,7 @@
     state:
       - symlinked
       - active
-    from: https://github.com/epfl-idevelop/jahia2wp/raw/release2018/data/wp/wp-content/plugins/enlighter.zip
+    from: https://github.com/epfl-si/jahia2wp/raw/release2018/data/wp/wp-content/plugins/enlighter.zip
 
 - name: enlighter configuration
   wordpress_option: "{{ item }}"
@@ -371,7 +371,7 @@
   wordpress_plugin:
     name: EPFL-Share
     state: "{{ plugins_symlinked_and_active_in_2010_only }}"
-    from: https://github.com/epfl-idevelop/jahia2wp/tree/release/data/wp/wp-content/plugins/EPFL-Share
+    from: https://github.com/epfl-si/jahia2wp/tree/release/data/wp/wp-content/plugins/EPFL-Share
 
 - name: Shortcodes Ultimate plugin
   wordpress_plugin:
@@ -383,103 +383,103 @@
   wordpress_plugin:
     name: epfl-scheduler
     state: "{{ plugins_symlinked_and_active_in_2010_only }}"
-    from: https://github.com/epfl-idevelop/jahia2wp/tree/release/data/wp/wp-content/plugins/epfl-scheduler
+    from: https://github.com/epfl-si/jahia2wp/tree/release/data/wp/wp-content/plugins/epfl-scheduler
 
 - name: epfl-news plugin
   wordpress_plugin:
     name: epfl-news
     state: "{{ plugins_symlinked_and_active_in_2010_only }}"
-    from: https://github.com/epfl-idevelop/jahia2wp/tree/release/data/wp/wp-content/plugins/epfl-news
+    from: https://github.com/epfl-si/jahia2wp/tree/release/data/wp/wp-content/plugins/epfl-news
 
 - name: epfl-memento plugin
   wordpress_plugin:
     name: epfl-memento
     state: "{{ plugins_symlinked_and_active_in_2010_only }}"
-    from: https://github.com/epfl-idevelop/jahia2wp/tree/release/data/wp/wp-content/plugins/epfl-memento
+    from: https://github.com/epfl-si/jahia2wp/tree/release/data/wp/wp-content/plugins/epfl-memento
 
 - name: epfl-faq plugin
   wordpress_plugin:
     name: epfl-faq
     state: "{{ plugins_symlinked_and_active_in_2010_only }}"
-    from: https://github.com/epfl-idevelop/jahia2wp/tree/release/data/wp/wp-content/plugins/epfl-faq
+    from: https://github.com/epfl-si/jahia2wp/tree/release/data/wp/wp-content/plugins/epfl-faq
 
 - name: epfl-map plugin
   wordpress_plugin:
     name: epfl-map
     state: "{{ plugins_symlinked_and_active_in_2010_only }}"
-    from: https://github.com/epfl-idevelop/jahia2wp/tree/release/data/wp/wp-content/plugins/epfl-map
+    from: https://github.com/epfl-si/jahia2wp/tree/release/data/wp/wp-content/plugins/epfl-map
 
 - name: epfl-buttons plugin
   wordpress_plugin:
     name: epfl-buttons
     state: "{{ plugins_symlinked_and_active_in_2010_only }}"
-    from: https://github.com/epfl-idevelop/jahia2wp/tree/release/data/wp/wp-content/plugins/epfl-buttons
+    from: https://github.com/epfl-si/jahia2wp/tree/release/data/wp/wp-content/plugins/epfl-buttons
 
 - name: epfl-snippet plugin
   wordpress_plugin:
     name: epfl-snippet
     state: "{{ plugins_symlinked_and_active_in_2010_only }}"
-    from: https://github.com/epfl-idevelop/jahia2wp/tree/release/data/wp/wp-content/plugins/epfl-snippet
+    from: https://github.com/epfl-si/jahia2wp/tree/release/data/wp/wp-content/plugins/epfl-snippet
 
 - name: epfl-toggle plugin
   wordpress_plugin:
     name: epfl-toggle
     state: "{{ plugins_symlinked_and_active_in_2010_only }}"
-    from: https://github.com/epfl-idevelop/jahia2wp/tree/release/data/wp/wp-content/plugins/epfl-toggle
+    from: https://github.com/epfl-si/jahia2wp/tree/release/data/wp/wp-content/plugins/epfl-toggle
 
 - name: epfl-grid plugin
   wordpress_plugin:
     name: epfl-grid
     state: "{{ plugins_symlinked_and_active_in_2010_only }}"
-    from: https://github.com/epfl-idevelop/jahia2wp/tree/release/data/wp/wp-content/plugins/epfl-grid
+    from: https://github.com/epfl-si/jahia2wp/tree/release/data/wp/wp-content/plugins/epfl-grid
 
 - name: epfl-infoscience plugin
   wordpress_plugin:
     name: epfl-infoscience
     state: "{{ plugins_symlinked_and_active_in_2010_only }}"
-    from: https://github.com/epfl-idevelop/jahia2wp/tree/release/data/wp/wp-content/plugins/epfl-infoscience
+    from: https://github.com/epfl-si/jahia2wp/tree/release/data/wp/wp-content/plugins/epfl-infoscience
 
 - name: epfl-infoscience-search plugin
   wordpress_plugin:
     name: epfl-infoscience-search
     state: "{{ plugins_symlinked_and_active_in_2010_only }}"
-    from: https://github.com/epfl-idevelop/jahia2wp/tree/release/data/wp/wp-content/plugins/epfl-infoscience-search
+    from: https://github.com/epfl-si/jahia2wp/tree/release/data/wp/wp-content/plugins/epfl-infoscience-search
 
 - name: epfl-xml plugin
   wordpress_plugin:
     name: epfl-xml
     state: "{{ plugins_symlinked_and_active_in_2010_only }}"
-    from: https://github.com/epfl-idevelop/jahia2wp/tree/release/data/wp/wp-content/plugins/epfl-xml
+    from: https://github.com/epfl-si/jahia2wp/tree/release/data/wp/wp-content/plugins/epfl-xml
 
 - name: epfl-people plugin
   wordpress_plugin:
     name: epfl-people
     state: "{{ plugins_symlinked_and_active_in_2010_only }}"
-    from: https://github.com/epfl-idevelop/jahia2wp/tree/release/data/wp/wp-content/plugins/epfl-people
+    from: https://github.com/epfl-si/jahia2wp/tree/release/data/wp/wp-content/plugins/epfl-people
 
 - name: epfl-twitter plugin
   wordpress_plugin:
     name: epfl-twitter
     state: "{{ plugins_symlinked_and_active_in_2010_only }}"
-    from: https://github.com/epfl-idevelop/jahia2wp/tree/release/data/wp/wp-content/plugins/epfl-twitter
+    from: https://github.com/epfl-si/jahia2wp/tree/release/data/wp/wp-content/plugins/epfl-twitter
 
 - name: epfl-video plugin
   wordpress_plugin:
     name: epfl-video
     state: "{{ plugins_symlinked_and_active_in_2010_only }}"
-    from: https://github.com/epfl-idevelop/jahia2wp/tree/release/data/wp/wp-content/plugins/epfl-video
+    from: https://github.com/epfl-si/jahia2wp/tree/release/data/wp/wp-content/plugins/epfl-video
 
 - name: epfl-tableau plugin
   wordpress_plugin:
     name: epfl-tableau
     state: "{{ plugins_symlinked_and_active_in_2010_only }}"
-    from: https://github.com/epfl-idevelop/jahia2wp/tree/release/data/wp/wp-content/plugins/epfl-tableau
+    from: https://github.com/epfl-si/jahia2wp/tree/release/data/wp/wp-content/plugins/epfl-tableau
 
 - name: epfl-google-forms plugin
   wordpress_plugin:
     name: epfl-google-forms
     state: "{{ plugins_symlinked_and_active_in_2010_only }}"
-    from: https://github.com/epfl-idevelop/jahia2wp/tree/release/data/wp/wp-content/plugins/epfl-google-forms
+    from: https://github.com/epfl-si/jahia2wp/tree/release/data/wp/wp-content/plugins/epfl-google-forms
 
 ##################### Category-specific plugins ###########################
 
@@ -487,35 +487,35 @@
   wordpress_plugin:
     name: epfl-intranet
     state: "{{ plugins_for_inside_category }}"
-    from: https://github.com/epfl-idevelop/wp-plugin-epfl-intranet
+    from: https://github.com/epfl-si/wp-plugin-epfl-intranet
 
 - name: epfl-emploi plugin
   wordpress_plugin:
     name: epfl-emploi
     state: "{{ plugins_for_emploi_category }}"
-    from: https://github.com/epfl-idevelop/jahia2wp/tree/release2018/data/wp/wp-content/plugins/epfl-emploi
+    from: https://github.com/epfl-si/jahia2wp/tree/release2018/data/wp/wp-content/plugins/epfl-emploi
 
 - name: epfl-restauration plugin
   wordpress_plugin:
     name: epfl-restauration
     state: "{{ plugins_for_restauration_category }}"
     from: https://github.com/epfl-idevelop/jahia2wp/tree/release2018/data/wp/wp-content/plugins/epfl-restauration
+    from: https://github.com/epfl-si/jahia2wp/tree/release2018/data/wp/wp-content/plugins/epfl-restauration
 
 - name: epfl-scienceqa plugin
   wordpress_plugin:
     name: epfl-scienceqa
     state: "{{ plugins_for_scienceqa_category }}"
-    from: https://github.com/epfl-idevelop/wp-plugin-epfl-scienceqa
+    from: https://github.com/epfl-si/wp-plugin-epfl-scienceqa
 
 - name: EPFL-Library-Plugins plugin
   wordpress_plugin:
     name: EPFL-Library-Plugins
     state: "{{ plugins_for_library_category }}"
-    from: https://github.com/epfl-idevelop/jahia2wp/tree/release2018/data/wp/wp-content/plugins/EPFL-Library-Plugins
+    from: https://github.com/epfl-si/jahia2wp/tree/release2018/data/wp/wp-content/plugins/EPFL-Library-Plugins
 
 - name: epfl-courses-se plugin
   wordpress_plugin:
     name: epfl-courses-se
     state: "{{ plugins_for_cdhshs_category }}"
-    from: https://github.com/epfl-idevelop/jahia2wp/tree/release2018/data/wp/wp-content/plugins/epfl-courses-se
-    
+    from: https://github.com/epfl-si/jahia2wp/tree/release2018/data/wp/wp-content/plugins/epfl-courses-se

--- a/ansible/roles/wordpress-instance/tasks/plugins.yml
+++ b/ansible/roles/wordpress-instance/tasks/plugins.yml
@@ -499,7 +499,6 @@
   wordpress_plugin:
     name: epfl-restauration
     state: "{{ plugins_for_restauration_category }}"
-    from: https://github.com/epfl-idevelop/jahia2wp/tree/release2018/data/wp/wp-content/plugins/epfl-restauration
     from: https://github.com/epfl-si/jahia2wp/tree/release2018/data/wp/wp-content/plugins/epfl-restauration
 
 - name: epfl-scienceqa plugin

--- a/ansible/roles/wordpress-instance/tasks/restore-over-ssh.yml
+++ b/ansible/roles/wordpress-instance/tasks/restore-over-ssh.yml
@@ -44,7 +44,7 @@
       {{ backup_prod_shell_untar }} --wildcards --wildcards-match-slash */wp-content/uploads
 
 # Temporary kludge for incremental backups that span across directory
-# rename operations such as https://github.com/epfl-idevelop/jahia2wp/pull/452
+# rename operations such as https://github.com/epfl-si/jahia2wp/pull/452
 - name: Remove duplicate plugins (temporary kludge)
   shell:
     cmd: |

--- a/ansible/roles/wordpress-openshift-namespace/vars/continuous-integration-vars.yml
+++ b/ansible/roles/wordpress-openshift-namespace/vars/continuous-integration-vars.yml
@@ -8,13 +8,13 @@ ci_buildconfig_name: "{{ ci_name_stem }}-{{ ci_prod_or_dev }}"
 
 ci_jenkins_master_image_name: jenkins-openshift-epfl
 ci_jenkins_master_git_build:
-  repository: 'https://github.com/epfl-idevelop/wp-ops'
+  repository: 'https://github.com/epfl-si/wp-ops'
   ref: wwp-continuous-integration
   path: docker/jenkins
 
 ci_jenkins_test_sidekick_image_name: cucumberjs
 ci_jenkins_test_sidekick_git_build:
-  repository: 'https://github.com/epfl-idevelop/wp-dev'
+  repository: 'https://github.com/epfl-si/wp-dev'
   path: acceptance
 
 ci_jenkins_slave_image_name: "jenkins-agent"

--- a/ansible/roles/wordpress-openshift-namespace/vars/image-vars.yml
+++ b/ansible/roles/wordpress-openshift-namespace/vars/image-vars.yml
@@ -2,4 +2,4 @@ httpd_image_name: httpd
 mgmt_image_name: mgmt
 wp_base_image_name: wp-base
 
-wp_ops_git_uri: https://github.com/epfl-idevelop/wp-ops
+wp_ops_git_uri: https://github.com/epfl-si/wp-ops

--- a/docker/cronjob/Dockerfile
+++ b/docker/cronjob/Dockerfile
@@ -1,3 +1,3 @@
-FROM epflidevelop/os-wp-mgmt
+FROM epflsi/os-wp-mgmt
 
 USER www-data

--- a/docker/httpd/Dockerfile
+++ b/docker/httpd/Dockerfile
@@ -1,4 +1,4 @@
-FROM epflidevelop/os-wp-base
+FROM epflsi/os-wp-base
 
 RUN apt-get -qy update && apt-get -qy install --no-install-recommends \
     apache2 \

--- a/docker/mgmt/Dockerfile
+++ b/docker/mgmt/Dockerfile
@@ -1,4 +1,4 @@
-FROM epflidevelop/os-wp-base
+FROM epflsi/os-wp-base
 
 RUN apt-get -qy update && apt-get -qy install --no-install-recommends \
     bash-completion \

--- a/docker/mgmt/Dockerfile
+++ b/docker/mgmt/Dockerfile
@@ -42,7 +42,7 @@ RUN chmod a+x /usr/local/bin/new-wp-site
 COPY ./docker-entrypoint.sh /
 
 ARG WP_OPS_BRANCH=master
-RUN set -e -x; cd /wp; git clone https://github.com/epfl-idevelop/wp-ops; \
+RUN set -e -x; cd /wp; git clone https://github.com/epfl-si/wp-ops; \
     cd wp-ops; git checkout ${WP_OPS_BRANCH}
 
 # setup access rights

--- a/docker/wp-base/Dockerfile
+++ b/docker/wp-base/Dockerfile
@@ -75,7 +75,7 @@ RUN su -s /bin/sh www-data -c " \
     fi;                                                                   \
     wp package install https://github.com/diggy/polylang-cli.git ;        \
     wp package install /tmp/cortneyray/; \
-    wp package install https://github.com/epfl-idevelop/wp-cli.git;       \
+    wp package install https://github.com/epfl-si/wp-cli.git;       \
     rm -f ~/.composer/auth.json"
 
 

--- a/docker/wp-base/install-plugins-and-themes.py
+++ b/docker/wp-base/install-plugins-and-themes.py
@@ -17,7 +17,7 @@ import tempfile
 import yaml
 from zipfile import ZipFile
 
-AUTO_MANIFEST_URL = 'https://raw.githubusercontent.com/epfl-idevelop/wp-ops/master/ansible/roles/wordpress-instance/tasks/plugins.yml'
+AUTO_MANIFEST_URL = 'https://raw.githubusercontent.com/epfl-si/wp-ops/master/ansible/roles/wordpress-instance/tasks/plugins.yml'
 
 def usage():
     print("""
@@ -293,13 +293,13 @@ class Themes:
     def all(cls):
         return (
             Plugin('wp-theme-2018',
-                   ['https://github.com/epfl-idevelop/wp-theme-2018/tree/master/wp-theme-2018']),
+                   ['https://github.com/epfl-si/wp-theme-2018/tree/master/wp-theme-2018']),
             Plugin('wp-theme-light',
-                   ['https://github.com/epfl-idevelop/wp-theme-2018/tree/master/wp-theme-light']),
+                   ['https://github.com/epfl-si/wp-theme-2018/tree/master/wp-theme-light']),
             Plugin('epfl-blank',
-                   ['https://github.com/epfl-idevelop/jahia2wp/tree/release/data/wp/wp-content/themes/epfl-blank']),
+                   ['https://github.com/epfl-si/jahia2wp/tree/release/data/wp/wp-content/themes/epfl-blank']),
             Plugin('epfl-master',
-                   ['https://github.com/epfl-idevelop/jahia2wp/tree/release/data/wp/wp-content/themes/epfl-master'])
+                   ['https://github.com/epfl-si/jahia2wp/tree/release/data/wp/wp-content/themes/epfl-master'])
         )
 
 


### PR DESCRIPTION
Following the rename of the epfl-idevelop GitHub organization to epfl-si today, we want to update all pointers (despite the old addresses still working for now).
