### PR TITLE
Dont update unit infos

### DIFF
--- a/ansible/roles/wordpress-instance/tasks/plugins.yml
+++ b/ansible/roles/wordpress-instance/tasks/plugins.yml
@@ -189,15 +189,15 @@
     name: plugin:epfl_accred:administrator_group
     value: "{{ wp_administrator_group }}"
 
-- name: accred unit name
-  wordpress_option:
-    name: plugin:epfl_accred:unit
-    value: "{{ wp_unit_name }}"
+# - name: accred unit name
+#   wordpress_option:
+#     name: plugin:epfl_accred:unit
+#     value: "{{ wp_unit_name }}"
 
-- name: accred unit ID
-  wordpress_option:
-    name: plugin:epfl_accred:unit_id
-    value: "{{ wp_unit_id }}"
+# - name: accred unit ID
+#   wordpress_option:
+#     name: plugin:epfl_accred:unit_id
+#     value: "{{ wp_unit_id }}"
 
 - name: Cache-Control plugin
   wordpress_plugin:

--- a/ansible/roles/wordpress-instance/tasks/plugins.yml
+++ b/ansible/roles/wordpress-instance/tasks/plugins.yml
@@ -189,6 +189,7 @@
     name: plugin:epfl_accred:administrator_group
     value: "{{ wp_administrator_group }}"
 
+# TODO WHEN WE WILL HAVE INFORMATION FROM WP-VERITAS
 # - name: accred unit name
 #   wordpress_option:
 #     name: plugin:epfl_accred:unit


### PR DESCRIPTION
Petit "piège" suite à l'implémentation d'un "Action Plugin" pour traiter les options des plugins... il y avait des options pour Accred qui étaient codées depuis longtemps avec des valeurs bidon mais jamais mises à jours dans les sites car le "Action Plugin" pour faire le boulot n'existait pas... et là, du coup, ça pète le site car ça mets des valeurs par défaut...