### PR TITLE
Some plugins still weren't taken...

### DIFF
--- a/docker/wp-base/install-plugins-and-themes.py
+++ b/docker/wp-base/install-plugins-and-themes.py
@@ -330,10 +330,8 @@ class WpOpsPlugins:
             # Defining if is MU-Plugin or not
             is_mu = False if 'is_mu' not in options else options['is_mu']
 
-            # For unwanted plugins, ... ugly ducklings !
+            # For unwanted plugins, the ones who are present but have to be uninstalled, ... ugly ducklings !
             if 'from' not in options:
-                continue
-            if not is_mu and ('state' in options and 'absent' in options['state']):
                 continue
 
             name = options['name']

--- a/docker/wp-base/install-plugins-and-themes.py
+++ b/docker/wp-base/install-plugins-and-themes.py
@@ -331,6 +331,8 @@ class WpOpsPlugins:
             is_mu = False if 'is_mu' not in options else options['is_mu']
 
             # For unwanted plugins, the ones who are present but have to be uninstalled, ... ugly ducklings !
+            # those ones have 'absent' for 'state' but this field is not used, it is only the missing 'from' which
+            # prevent plugin from being present in image.
             if 'from' not in options:
                 continue
 


### PR DESCRIPTION
Encore une condition en trop qui faisait que certaines plugins n'étaient pas pris en compte. Elle avait été laissée pour les plugins  `hello` et `akismet` qui sont par défaut dans WordPress et que l'on veut désinstaller.
Mais ne pas mettre l'entrée `from` dans les informations du plugin dans le fichier `plugins.yml` suffit à faire en sorte qu'ils ne soient pas installés.