### PR TITLE
More on Actions Plugins

### DIFF
--- a/ansible/inventory/wp_inventory.py
+++ b/ansible/inventory/wp_inventory.py
@@ -147,7 +147,9 @@ class WPInventory():
                             
         # We take only the minimum details we need for script correct execution    
         else:
-            options_to_get = [ 'epfl:site_category']
+            options_to_get = [ 'epfl:site_category',
+                                # contains theme name
+                                'stylesheet']
 
         # Default value for options
         for option_name in options_to_get:

--- a/ansible/inventory/wp_inventory.py
+++ b/ansible/inventory/wp_inventory.py
@@ -137,19 +137,19 @@ class WPInventory():
         section = 'options'
         details[section] = {}
 
-        # We have to return all details
-        if include_all_details:
-            # List of options to get from Instance
-            options_to_get = ['plugin:epfl_accred:unit_id', 
+        # List of basic options to get from Instance
+        options_to_get = [ 'plugin:epfl_accred:unit_id', 
                             'plugin:epfl_accred:unit',
                             'epfl:site_category',
-                            'siteurl']
-                            
-        # We take only the minimum details we need for script correct execution    
-        else:
-            options_to_get = [ 'epfl:site_category',
-                                # contains theme name
-                                'stylesheet']
+                            # contains theme name
+                            'stylesheet']
+
+        
+        # We have to return all details
+        if include_all_details:
+            # Adding options to initial list
+            options_to_get += ['siteurl']
+             
 
         # Default value for options
         for option_name in options_to_get:

--- a/ansible/roles/wordpress-instance/action_plugins/wordpress_action_module.py
+++ b/ansible/roles/wordpress-instance/action_plugins/wordpress_action_module.py
@@ -28,6 +28,12 @@ class WordPressActionModule(ActionBase):
             '%s %s' % (self._get_ansible_var('wp_cli_command'), args))
 
 
+    def _run_php_code(self, code):
+        result = self._run_shell_action("php -r '%s'" % (code))
+
+        return result['stdout_lines']
+
+
     def _run_shell_action (self, cmd):
         """
         Executes a Shell command
@@ -50,11 +56,11 @@ class WordPressActionModule(ActionBase):
                                       module_args=args, tmp=self._tmp,
                                       task_vars=self._task_vars)
         
-        
         # If command was to update an option using WP CLI
         if '_raw_params' in args and re.match(r'^wp\s--path=(.+)\soption\supdate', args['_raw_params']):
-            
             # We update 'changed' key depending on what was done by WPCLI
+            # NOTE: For an unknown reason, for some options, even if we set 'changed' to False 
+            # when nothing is changed, somewhere, the value is changed to True... !?!
             result['changed'] = not result['stdout'].endswith('option is unchanged.')
         
         self._update_result(result)

--- a/ansible/roles/wordpress-instance/action_plugins/wordpress_action_module.py
+++ b/ansible/roles/wordpress-instance/action_plugins/wordpress_action_module.py
@@ -14,9 +14,164 @@ class WordPressActionModule(ActionBase):
 
         self._tmp = tmp
         self._task_vars = task_vars
+        # Has to be set in child classes with one of the following value:
+        # plugin
+        # mu-plugin
+        # theme
+        self._type = None
+        # Has to be set with element name in child class
+        self._name = None
+
 
         return super(WordPressActionModule, self).run(tmp, task_vars)
 
+    @property
+    def type(self):
+        """
+        Return element type or raise an exception if not initialized
+        """
+        if not self._type:
+            raise ValueError("Please initiliaze 'self._type' in children class {}".format(type(self).__name__))
+            
+        return self._type
+
+    @property
+    def name(self):
+        """
+        Return element name or raise an exception if not initialized
+        """
+        if not self._name:
+            raise ValueError("Please initiliaze 'self._name' in children class {}".format(type(self).__name__))
+            
+        return self._name
+    
+
+    def _get_desired_state(self):
+        """
+        Returns array with installation state and activation state for a (mu-)plugin.
+        We look into YAML given args (plugins.yml)
+        """
+        desired_state = self._task.args.get('state', 'absent')
+        if isinstance(desired_state, six.string_types):
+             desired_state = set([desired_state.strip()])
+        elif isinstance(desired_state, list):
+            desired_state = set(desired_state)
+        else:
+            raise TypeError("Unexpected value for `state`: %s" % desired_state)
+
+        if 'symlinked' in desired_state and 'installed' in desired_state:
+            raise ValueError('% %s cannot be both `symlinked` and `installed`' % self.type, self.name)
+
+        installation_state = self._installation_state(desired_state)
+        activation_state = self._activation_state(desired_state)
+
+        if installation_state == 'absent' and (activation_state == 'active' or self._is_mu):
+            raise ValueError('%s %s cannot be simultaneously absent and %s' %
+                             self.type, self.name, activation_state)
+
+        if activation_state == 'active' or self._is_mu:
+            # Cannot activate (or make a mu-plugin) if not installed
+            if not installation_state:
+                installation_state = 'symlinked'
+        if installation_state == 'absent':
+            # Must (attempt to) deactivate prior to uninstalling
+            if not activation_state:
+                activation_state = "inactive"
+
+        return (installation_state, activation_state)
+    
+
+
+    def _activation_state(self, desired_state):
+        """
+        Returns plugin activation state based on desired state (active, inactive)
+
+        :param desired_state: Plugin desired activation state
+        """
+
+        # Active by default
+        if self._is_mu:
+            return 'active'
+
+        activation_state = desired_state.intersection(['active', 'inactive'])
+        if len(activation_state) == 0:
+            return None
+        elif len(activation_state) == 1:
+            return list(activation_state)[0]
+        else:
+            raise ValueError('%s %s cannot be simultaneously %s' % self.type, self.name, str(list(activation_state)))
+
+
+    def _installation_state(self, desired_state):
+        """
+        Returns plugin installation state based on desired state (present, absent, symlinked)
+
+        :param desired_state: Plugin desired installation state
+        """
+        installation_state = desired_state.intersection(['present', 'absent', 'symlinked'])
+        if len(installation_state) == 0:
+            return None
+        elif len(installation_state) == 1:
+            return list(installation_state)[0]
+        else:
+            raise ValueError('%s %s cannot be simultaneously %s' % self.type, self.name, str(list(installation_state)))
+
+
+    def _do_symlink_file (self, basename):
+        """
+        Creates a symlink for a given plugin file/folder
+
+        :param basename: given plugin file/folder for which we have to create a symlink
+        """
+        return self._run_action('file', {
+            'state': 'link',
+            # Beware src / path inversion, as is customary with everything symlink:
+            'src': self._get_symlink_target(basename),
+            'path': self._get_symlink_path(basename),
+            })
+
+    
+    def _do_rimraf_file (self, basename):
+        """
+        Remove a file/folder belonging to a plugin
+
+        :param basename: given plugin file/folder
+        """
+        self._run_action('file',
+                         {'state': 'absent',
+                          'path': self._get_symlink_path(basename)})
+        return self.result
+
+    
+    def _get_symlink_path (self, basename):
+        """
+        Returns symlink source path
+
+        :param basename: given plugin file/folder for which we want the symlink source path
+        """
+        return self._make_element_path(self._get_wp_dir(), basename)
+
+
+    def _get_symlink_target (self, basename):
+        """
+        Returns a path to symlink target (mu-)plugin or theme file/folder
+
+        :param basename: given plugin file/folder for which we want the symlink target path
+        """
+        return self._make_element_path('../../wp', basename)
+
+
+    def _make_element_path (self, prefix, basename):
+        """
+        Generates an absolute (mu-)plugin or theme path.
+
+        :param prefix: string to add at the beginning of the path to have an absolute one
+        :param basename: given plugin file/folder for which we want the symlink source path
+        """
+        return '%s/wp-content/%ss/%s' % (
+            prefix,
+            self.type,
+            basename)        
 
     def _run_wp_cli_action (self, args):
         """
@@ -29,6 +184,11 @@ class WordPressActionModule(ActionBase):
 
 
     def _run_php_code(self, code):
+        """
+        Execute PHP code and returns result
+
+        :param code: Code to execute
+        """
         result = self._run_shell_action("php -r '%s'" % (code))
 
         return result['stdout_lines']

--- a/ansible/roles/wordpress-instance/action_plugins/wordpress_option.py
+++ b/ansible/roles/wordpress-instance/action_plugins/wordpress_option.py
@@ -1,10 +1,10 @@
 import sys
 import os.path
+import re
 
 # To be able to include package wp_inventory in parent directory
 sys.path.append(os.path.dirname(__file__))
 
-from ansible.plugins.action import ActionBase
 from wordpress_action_module import WordPressActionModule
 
 
@@ -25,8 +25,26 @@ class ActionModule(WordPressActionModule):
         NOTE: Apart 'name' and 'value', we could also have an 'autoload' value but after some tests,
         WP-CLI, even if documented to use '--autoload' parameter, raises an error...
         """
+
+        option_value = str(self._task.args.get('value')).strip()
         
-        cmd = "option update {} '{}'".format(self._task.args.get('name'), self._task.args.get('value'))        
+        json_format = ''
+
+        # If option is serialized
+        if re.match(r'^a:\d+:\{.*\}', option_value):
+            
+            # Escaping double quotes to avoid problems and unserializing option value and converting it to JSON to reuse it
+            # We use PHP do to this because Python doesn't have the appropriate functions for this.. not his job !
+            php_cmd = 'echo json_encode(unserialize("{0}"));'.format(option_value.replace('"', '\\"'))
+            option_value = self._run_php_code(php_cmd)
+
+            option_value = option_value[0] if len(option_value) > 0 else ''
+
+            # If we have a value, it is JSON
+            if option_value != '':
+                json_format = '--format=json'
+
+        cmd = "option update {} {} '{}' --skip-themes --skip-plugins".format(json_format, self._task.args.get('name'), option_value)
 
         return self._run_wp_cli_action(cmd)
 

--- a/ansible/roles/wordpress-instance/action_plugins/wordpress_plugin.py
+++ b/ansible/roles/wordpress-instance/action_plugins/wordpress_plugin.py
@@ -34,12 +34,8 @@ class ActionModule(WordPressActionModule):
             if 'failed' in self.result: return self.result
 
         if desired_installation_state:
-            # We don't second-guess mu-plugins - If the activation
-            # state is left vague, then they will be "demoted" to
-            # ordinary plug-ins.
+            # Setting desired installation state
             self._ensure_all_files_state(desired_installation_state)
-            if 'failed' in self.result: return self.result
-            self._ensure_all_files_state('absent')
             if 'failed' in self.result: return self.result
 
         if (
@@ -60,7 +56,6 @@ class ActionModule(WordPressActionModule):
 
         :param desired_state: can be 'installed', 'symlinked', ...
         """
-
         froms = self._task.args.get('from')
         if isinstance(froms, six.string_types):
             froms = [froms]

--- a/ansible/roles/wordpress-instance/action_plugins/wordpress_plugin.py
+++ b/ansible/roles/wordpress-instance/action_plugins/wordpress_plugin.py
@@ -23,7 +23,7 @@ class ActionModule(WordPressActionModule):
         self._mandatory = self._task.args.get('is_mu', False)
         self._type = 'mu-plugin' if self._task.args.get('is_mu', False) else 'plugin'
 
-        current_activation_state = self._get_plugin_activation_state()
+        current_activation_state = self._get_activation_state()
         (desired_installation_state,
          desired_activation_state) = self._get_desired_state()
 
@@ -56,21 +56,5 @@ class ActionModule(WordPressActionModule):
         """
         Uses WP-CLI to deactivate plugin
         """
-        return self._run_wp_cli_action('plugin deactivate %s' % self._get_name())
+        return self._run_wp_cli_action('plugin deactivate {}'.format(self._get_name()))
 
-
-    def _get_plugin_activation_state (self):
-        """
-        Returns plugin activation state
-        """
-        oldresult = deepcopy(self.result)
-        result = self._run_wp_cli_action('plugin list --format=csv')
-        if 'failed' in self.result: return
-
-        self.result = oldresult  # We don't want "changed" to pollute the state
-
-        for line in result["stdout"].splitlines()[1:]:
-            fields = line.split(',')
-            if len(fields) < 2: continue
-            if fields[0] == self._get_name(): return fields[1]
-        return 'inactive'

--- a/ansible/roles/wordpress-instance/action_plugins/wordpress_plugin.py
+++ b/ansible/roles/wordpress-instance/action_plugins/wordpress_plugin.py
@@ -46,92 +46,10 @@ class ActionModule(WordPressActionModule):
         ):
             
             
-            self._update_result(self._do_activate_plugin())
+            self._update_result(self._do_activate_element())
             if 'failed' in self.result: return self.result
 
         return self.result
-
-
-    def _ensure_all_files_state (self, desired_state):
-        """
-        Checks if all files/folder for a plugin are in the desired states (present, absent, ...)
-
-        :param desired_state: can be 'installed', 'symlinked', ...
-        """
-        froms = self._task.args.get('from')
-        if isinstance(froms, six.string_types):
-            froms = [froms]
-        if not froms:
-            froms = []
-        
-        basenames = [os.path.basename(f) for f in froms
-                if self._is_filename(f)]
-        if not basenames:
-            basenames = [self._get_name()]
-
-        # Going through each files/folder for plugin
-        for basename in basenames:
-            self._ensure_file_state(desired_state, basename)
-            if 'failed' in self.result: return self.result
-
-
-
-    def _ensure_file_state (self, desired_state, basename):
-        """
-        Check if a given (mu-)plugin file/folder is at the desired state
-
-        :param desired_state: can be 'installed', 'symlinked', ...
-        :param basename: name of element to check (can be a file or folder)
-        """
-        current_state = set([self._get_current_file_state(basename)])
-        to_do = set([desired_state]) - current_state
-        to_undo = current_state - set([desired_state])
-
-        if not (to_do or to_undo):
-            return
-
-        if 'installed' in to_do:
-            raise NotImplementedError('Installing "regular" (non-symlinked) plugin %s '
-                                      'not supported (yet)' % basename)
-
-        if 'symlinked' in to_undo or 'installed' in to_undo:
-            self._update_result(self._do_rimraf_file(basename))
-            if 'failed' in self.result: return self.result
-
-        if 'symlinked' in to_do:
-            self._update_result(self._do_symlink_file(basename))
-            if 'failed' in self.result: return self.result
-
-
-    def _get_current_file_state (self, basename):
-        """
-        Returns state of a given plugin file/folder.
-
-        :param basename: name of element to check (can be a file or folder)
-        """
-        path = self._get_symlink_path(basename)
-        plugin_stat = self._run_action('stat', { 'path': path })
-        if 'failed' in plugin_stat:
-            raise AnsibleActionFail("Cannot stat() %s" % path)
-        file_exists = ('stat' in plugin_stat and plugin_stat['stat']['exists'])
-        if not file_exists:
-                return 'absent'
-        elif plugin_stat['stat']['islnk']:
-            if (plugin_stat['stat']['lnk_target'] ==
-                self._get_symlink_target(basename)):
-                return 'symlinked'
-            else:
-                return 'symlink_damaged'
-        else:
-            return 'installed'
-
-
-
-    def _do_activate_plugin (self):
-        """
-        Uses WP-CLI to activate plugin
-        """
-        return self._run_wp_cli_action('plugin activate %s' % self._get_name())
 
 
     def _do_deactivate_plugin (self):

--- a/ansible/roles/wordpress-instance/action_plugins/wordpress_plugin.py
+++ b/ansible/roles/wordpress-instance/action_plugins/wordpress_plugin.py
@@ -19,8 +19,10 @@ class ActionModule(WordPressActionModule):
 
         self.result = super(ActionModule, self).run(tmp, task_vars)
         
-        self._plugin_name = self._task.args.get('name')
+        self._name = self._task.args.get('name')
         self._is_mu = self._task.args.get('is_mu', False)
+
+        self._type = 'mu-plugin' if self._task.args.get('is_mu', False) else 'plugin'
 
         current_activation_state = self._get_plugin_activation_state()
         (desired_installation_state,
@@ -65,7 +67,7 @@ class ActionModule(WordPressActionModule):
         basenames = [os.path.basename(f) for f in froms
                 if self._is_filename(f)]
         if not basenames:
-            basenames = [self._plugin_name]
+            basenames = [self.name]
 
         # Going through each files/folder for plugin
         for basename in basenames:
@@ -93,11 +95,11 @@ class ActionModule(WordPressActionModule):
                                       'not supported (yet)' % basename)
 
         if 'symlinked' in to_undo or 'installed' in to_undo:
-            self._update_result(self._do_rimraf_file(basename, self._is_mu))
+            self._update_result(self._do_rimraf_file(basename))
             if 'failed' in self.result: return self.result
 
         if 'symlinked' in to_do:
-            self._update_result(self._do_symlink_file(basename, self._is_mu))
+            self._update_result(self._do_symlink_file(basename))
             if 'failed' in self.result: return self.result
 
 
@@ -107,7 +109,7 @@ class ActionModule(WordPressActionModule):
 
         :param basename: name of element to check (can be a file or folder)
         """
-        path = self._get_symlink_path(basename, self._is_mu)
+        path = self._get_symlink_path(basename)
         plugin_stat = self._run_action('stat', { 'path': path })
         if 'failed' in plugin_stat:
             raise AnsibleActionFail("Cannot stat() %s" % path)
@@ -116,7 +118,7 @@ class ActionModule(WordPressActionModule):
                 return 'absent'
         elif plugin_stat['stat']['islnk']:
             if (plugin_stat['stat']['lnk_target'] ==
-                self._get_symlink_target(basename, self._is_mu)):
+                self._get_symlink_target(basename)):
                 return 'symlinked'
             else:
                 return 'symlink_damaged'
@@ -124,150 +126,19 @@ class ActionModule(WordPressActionModule):
             return 'installed'
 
 
-    def _get_desired_state(self):
-        """
-        Returns array with installation state and activation state for a (mu-)plugin.
-        We look into YAML given args (plugins.yml)
-        """
-        desired_state = self._task.args.get('state', 'absent')
-        if isinstance(desired_state, six.string_types):
-             desired_state = set([desired_state.strip()])
-        elif isinstance(desired_state, list):
-            desired_state = set(desired_state)
-        else:
-            raise TypeError("Unexpected value for `state`: %s" % desired_state)
-
-        if 'symlinked' in desired_state and 'installed' in desired_state:
-            raise ValueError('Plug-in %s cannot be both `symlinked` and `installed`' % self._plugin_name)
-
-        installation_state = self._installation_state(desired_state)
-        activation_state = self._activation_state(desired_state)
-
-        if installation_state == 'absent' and (activation_state == 'active' or self._is_mu):
-            raise ValueError('Plug-in %s cannot be simultaneously absent and %s' %
-                             self._plugin_name, activation_state)
-
-        if activation_state == 'active' or self._is_mu:
-            # Cannot activate (or make a mu-plugin) if not installed
-            if not installation_state:
-                installation_state = 'symlinked'
-        if installation_state == 'absent':
-            # Must (attempt to) deactivate prior to uninstalling
-            if not activation_state:
-                activation_state = "inactive"
-
-        return (installation_state, activation_state)
-
-
-    def _installation_state(self, desired_state):
-        """
-        Returns plugin installation state based on desired state (present, absent, symlinked)
-
-        :param desired_state: Plugin desired installation state
-        """
-        installation_state = desired_state.intersection(['present', 'absent', 'symlinked'])
-        if len(installation_state) == 0:
-            return None
-        elif len(installation_state) == 1:
-            return list(installation_state)[0]
-        else:
-            raise ValueError('Plug-in cannot be simultaneously %s' % str(list(installation_state)))
-
-
-    def _activation_state(self, desired_state):
-        """
-        Returns plugin activation state based on desired state (active, inactive)
-
-        :param desired_state: Plugin desired activation state
-        """
-
-        # Active by default
-        if self._is_mu:
-            return 'active'
-
-        activation_state = desired_state.intersection(['active', 'inactive'])
-        if len(activation_state) == 0:
-            return None
-        elif len(activation_state) == 1:
-            return list(activation_state)[0]
-        else:
-            raise ValueError('Plug-in %s cannot be simultaneously %s' % str(list(activation_state)))
-
-
-    def _do_symlink_file (self, basename, is_mu):
-        """
-        Creates a symlink for a given plugin file/folder
-
-        :param basename: given plugin file/folder for which we have to create a symlink
-        :param is_mu: Boolean to tell if it's a mu-plugin
-        """
-        return self._run_action('file', {
-            'state': 'link',
-            # Beware src / path inversion, as is customary with everything symlink:
-            'src': self._get_symlink_target(basename, is_mu),
-            'path': self._get_symlink_path(basename, is_mu),
-            })
-
-
-    def _get_symlink_target (self, basename, is_mu):
-        """
-        Returns a path to symlink target plugin file/folder
-
-        :param basename: given plugin file/folder for which we want the symlink target path
-        :param is_mu: Boolean to tell if it's a mu-plugin
-        """
-        return self._make_plugin_path('../../wp', basename, is_mu)
-
 
     def _do_activate_plugin (self):
         """
         Uses WP-CLI to activate plugin
         """
-        return self._run_wp_cli_action('plugin activate %s' % self._plugin_name)
+        return self._run_wp_cli_action('plugin activate %s' % self.name)
 
 
     def _do_deactivate_plugin (self):
         """
         Uses WP-CLI to deactivate plugin
         """
-        return self._run_wp_cli_action('plugin deactivate %s' % self._plugin_name)
-
-
-    def _do_rimraf_file (self, basename, is_mu):
-        """
-        Remove a file/folder belonging to a plugin
-
-        :param basename: given plugin file/folder
-        :param is_mu: Boolean to tell if it's a mu-plugin
-        """
-        self._run_action('file',
-                         {'state': 'absent',
-                          'path': self._get_symlink_path(basename, is_mu)})
-        return self.result
-
-
-    def _get_symlink_path (self, basename, is_mu):
-        """
-        Returns symlink source path
-
-        :param basename: given plugin file/folder for which we want the symlink source path
-        :param is_mu: Boolean to tell if it's a mu-plugin
-        """
-        return self._make_plugin_path(self._get_wp_dir(), basename, is_mu)
-
-
-    def _make_plugin_path (self, prefix, basename, is_mu):
-        """
-        Generates an absolute (mu-)plugin path.
-
-        :param prefix: string to add at the beginning of the path to have an absolute one
-        :param basename: given plugin file/folder for which we want the symlink source path
-        :param is_mu: Boolean to tell if it's a mu-plugin
-        """
-        return '%s/wp-content/%splugins/%s' % (
-            prefix,
-            'mu-' if is_mu else '',
-            basename)
+        return self._run_wp_cli_action('plugin deactivate %s' % self.name)
 
 
     def _get_plugin_activation_state (self):
@@ -283,5 +154,5 @@ class ActionModule(WordPressActionModule):
         for line in result["stdout"].splitlines()[1:]:
             fields = line.split(',')
             if len(fields) < 2: continue
-            if fields[0] == self._plugin_name: return fields[1]
+            if fields[0] == self.name: return fields[1]
         return 'inactive'

--- a/ansible/roles/wordpress-instance/action_plugins/wordpress_plugin.py
+++ b/ansible/roles/wordpress-instance/action_plugins/wordpress_plugin.py
@@ -20,8 +20,7 @@ class ActionModule(WordPressActionModule):
         self.result = super(ActionModule, self).run(tmp, task_vars)
         
         self._name = self._task.args.get('name')
-        self._is_mu = self._task.args.get('is_mu', False)
-
+        self._is_mandatory = self._task.args.get('is_mu', False)
         self._type = 'mu-plugin' if self._task.args.get('is_mu', False) else 'plugin'
 
         current_activation_state = self._get_plugin_activation_state()
@@ -41,7 +40,7 @@ class ActionModule(WordPressActionModule):
             if 'failed' in self.result: return self.result
 
         if (
-                not self._is_mu and
+                not self.is_mandatory and
                 bool(desired_activation_state) and
                 'active' in set([desired_activation_state]) - set([current_activation_state])
         ):
@@ -51,6 +50,7 @@ class ActionModule(WordPressActionModule):
             if 'failed' in self.result: return self.result
 
         return self.result
+
 
     def _ensure_all_files_state (self, desired_state):
         """

--- a/ansible/roles/wordpress-instance/action_plugins/wordpress_plugin.py
+++ b/ansible/roles/wordpress-instance/action_plugins/wordpress_plugin.py
@@ -20,7 +20,7 @@ class ActionModule(WordPressActionModule):
         self.result = super(ActionModule, self).run(tmp, task_vars)
         
         self._name = self._task.args.get('name')
-        self._is_mandatory = self._task.args.get('is_mu', False)
+        self._mandatory = self._task.args.get('is_mu', False)
         self._type = 'mu-plugin' if self._task.args.get('is_mu', False) else 'plugin'
 
         current_activation_state = self._get_plugin_activation_state()
@@ -40,7 +40,7 @@ class ActionModule(WordPressActionModule):
             if 'failed' in self.result: return self.result
 
         if (
-                not self.is_mandatory and
+                not self._is_mandatory() and
                 bool(desired_activation_state) and
                 'active' in set([desired_activation_state]) - set([current_activation_state])
         ):
@@ -67,7 +67,7 @@ class ActionModule(WordPressActionModule):
         basenames = [os.path.basename(f) for f in froms
                 if self._is_filename(f)]
         if not basenames:
-            basenames = [self.name]
+            basenames = [self._get_name()]
 
         # Going through each files/folder for plugin
         for basename in basenames:
@@ -131,14 +131,14 @@ class ActionModule(WordPressActionModule):
         """
         Uses WP-CLI to activate plugin
         """
-        return self._run_wp_cli_action('plugin activate %s' % self.name)
+        return self._run_wp_cli_action('plugin activate %s' % self._get_name())
 
 
     def _do_deactivate_plugin (self):
         """
         Uses WP-CLI to deactivate plugin
         """
-        return self._run_wp_cli_action('plugin deactivate %s' % self.name)
+        return self._run_wp_cli_action('plugin deactivate %s' % self._get_name())
 
 
     def _get_plugin_activation_state (self):
@@ -154,5 +154,5 @@ class ActionModule(WordPressActionModule):
         for line in result["stdout"].splitlines()[1:]:
             fields = line.split(',')
             if len(fields) < 2: continue
-            if fields[0] == self.name: return fields[1]
+            if fields[0] == self._get_name(): return fields[1]
         return 'inactive'

--- a/ansible/roles/wordpress-instance/action_plugins/wordpress_theme.py
+++ b/ansible/roles/wordpress-instance/action_plugins/wordpress_theme.py
@@ -1,6 +1,56 @@
-from ansible.plugins.action import ActionBase
 
+# There is a name clash with a module in Ansible named "copy":
+deepcopy = __import__('copy').deepcopy
 
-class ActionModule(ActionBase):
+import sys
+import os.path
+
+# To be able to include package wp_inventory in parent directory
+sys.path.append(os.path.dirname(__file__))
+
+from wordpress_action_module import WordPressActionModule
+
+class ActionModule(WordPressActionModule):
     def run(self, tmp=None, task_vars=None):
-        return super(ActionModule, self).run(tmp, task_vars)
+        self.result = super(ActionModule, self).run(tmp, task_vars)
+
+        self._name = self._task.args.get('name')
+        self._type = 'theme'
+        self._mandatory = False
+
+        current_activation_state = self._get_theme_activation_state()
+        (desired_installation_state,
+         desired_activation_state) = self._get_desired_state()
+
+        if desired_installation_state:
+            # Setting desired installation state
+            self._ensure_all_files_state(desired_installation_state)
+            if 'failed' in self.result: return self.result
+
+        if (
+                bool(desired_activation_state) and
+                'active' in set([desired_activation_state]) - set([current_activation_state])
+        ):
+            
+            
+            self._update_result(self._do_activate_element())
+            if 'failed' in self.result: return self.result
+
+        return self.result
+
+
+    def _get_theme_activation_state (self):
+        """
+        Returns plugin activation state
+        """
+        oldresult = deepcopy(self.result)
+        result = self._run_wp_cli_action('theme list --format=csv')
+        if 'failed' in self.result: return
+
+        self.result = oldresult  # We don't want "changed" to pollute the state
+
+        for line in result["stdout"].splitlines()[1:]:
+            fields = line.split(',')
+            if len(fields) < 2: continue
+            if fields[0] == self._get_name(): return fields[1]
+        return 'inactive'

--- a/ansible/roles/wordpress-instance/action_plugins/wordpress_theme.py
+++ b/ansible/roles/wordpress-instance/action_plugins/wordpress_theme.py
@@ -18,7 +18,7 @@ class ActionModule(WordPressActionModule):
         self._type = 'theme'
         self._mandatory = False
 
-        current_activation_state = self._get_theme_activation_state()
+        current_activation_state = self._get_activation_state()
         (desired_installation_state,
          desired_activation_state) = self._get_desired_state()
 
@@ -37,20 +37,3 @@ class ActionModule(WordPressActionModule):
             if 'failed' in self.result: return self.result
 
         return self.result
-
-
-    def _get_theme_activation_state (self):
-        """
-        Returns plugin activation state
-        """
-        oldresult = deepcopy(self.result)
-        result = self._run_wp_cli_action('theme list --format=csv')
-        if 'failed' in self.result: return
-
-        self.result = oldresult  # We don't want "changed" to pollute the state
-
-        for line in result["stdout"].splitlines()[1:]:
-            fields = line.split(',')
-            if len(fields) < 2: continue
-            if fields[0] == self._get_name(): return fields[1]
-        return 'inactive'

--- a/ansible/roles/wordpress-instance/tasks/plugins.yml
+++ b/ansible/roles/wordpress-instance/tasks/plugins.yml
@@ -192,16 +192,15 @@
     name: plugin:epfl_accred:administrator_group
     value: "{{ wp_administrator_group }}"
 
-# TODO WHEN WE WILL HAVE INFORMATION FROM WP-VERITAS
-# - name: accred unit name
-#   wordpress_option:
-#     name: plugin:epfl_accred:unit
-#     value: "{{ wp_unit_name }}"
+- name: accred unit name
+  wordpress_option:
+    name: plugin:epfl_accred:unit
+    value: "{{ wp_unit_name }}"
 
-# - name: accred unit ID
-#   wordpress_option:
-#     name: plugin:epfl_accred:unit_id
-#     value: "{{ wp_unit_id }}"
+- name: accred unit ID
+  wordpress_option:
+    name: plugin:epfl_accred:unit_id
+    value: "{{ wp_unit_id }}"
 
 - name: Cache-Control plugin
   wordpress_plugin:

--- a/ansible/roles/wordpress-instance/tasks/themes.yml
+++ b/ansible/roles/wordpress-instance/tasks/themes.yml
@@ -4,7 +4,27 @@
 
 - include_vars: theme-vars.yml
 
-- name: WordPress theme
+### 2018 Themes
+- name: WordPress theme 2018
   wordpress_theme:
-    name: '{{ theme_name }}'
-    state: symlinked
+    name: wp-theme-2018
+    state: '{{ [ "symlinked", "active" ] if theme_wp_theme_2018_active else "symlinked" }}'
+
+- name: WordPress theme 2018 (light)
+  wordpress_theme:
+    name: wp-theme-light
+    state: '{{ [ "symlinked", "active" ] if theme_wp_theme_light_active else "symlinked" }}'
+
+
+### 2010 Themes
+- name: WordPress theme 2010
+  wordpress_theme:
+    name: epfl-master
+    state: '{{ [ "symlinked", "active" ] if theme_epfl_master_active else "symlinked" }}'
+
+- name: WordPress theme 2010 (blank)
+  wordpress_theme:
+    name: epfl-blank
+    state: '{{ [ "symlinked", "active" ] if theme_epfl_blank_active else "symlinked" }}'
+
+

--- a/ansible/roles/wordpress-instance/vars/accred-vars.yml
+++ b/ansible/roles/wordpress-instance/vars/accred-vars.yml
@@ -1,4 +1,8 @@
 # Variables related to EPFL accred system and access control
 wp_administrator_group: WP_SuperAdmin
-wp_unit_name: "TODO obtain from wp-veritas"
-wp_unit_id: 1234   # also TODO
+
+# This should come from WP-Veritas inventory. If Ansible is run with an "existing sites" inventory,
+# current theme value will be read in database to fill "...["wp_details"]["options"]["plugin:epfl_accred:unit"]" and nothing will change
+# Using WP-Veritas inventory, value will be correct
+wp_unit_name: '{{ hostvars[inventory_hostname]["wp_details"]["options"]["plugin:epfl_accred:unit"] }}'
+wp_unit_id: '{{ hostvars[inventory_hostname]["wp_details"]["options"]["plugin:epfl_accred:unit_id"] }}'

--- a/ansible/roles/wordpress-instance/vars/theme-vars.yml
+++ b/ansible/roles/wordpress-instance/vars/theme-vars.yml
@@ -2,3 +2,13 @@
 
 # TODO: This should be computed from wp-veritas state
 theme_name: "wp-theme-2018"
+
+
+### 2018 Themes
+theme_wp_theme_2018_active: '{{ theme_name == "wp-theme-2018" }}'
+theme_wp_theme_light_active: '{{ theme_name == "wp-theme-light" }}'
+
+
+### 2010 Themes
+theme_epfl_blank_active: '{{ theme_name == "epfl-blank" }}'
+theme_epfl_master_active: '{{ theme_name == "epfl-master" }}'

--- a/ansible/roles/wordpress-instance/vars/theme-vars.yml
+++ b/ansible/roles/wordpress-instance/vars/theme-vars.yml
@@ -1,7 +1,9 @@
 # Theme variables go here
 
-# TODO: This should be computed from wp-veritas state
-theme_name: "wp-theme-2018"
+# This should come from WP-Veritas inventory. If Ansible is run with an "existing sites" inventory,
+# current theme value will be read in database to fill "wp_details.options.stylesheet" and nothing will change
+# Using WP-Veritas inventory, value will be correct
+theme_name: '{{ hostvars[inventory_hostname]["wp_details"]["options"]["stylesheet"] }}'
 
 
 ### 2018 Themes


### PR DESCRIPTION
- Correction d'un bug dans la gestion des plugins
- Ajout de la gestion de la mise à jour des options de plugins, y compris de celles qui sont sérialisées (passage par PHP pour les désérialiser et les encoder en JSON)
- Réorganisation du code pour mettre plus d'éléments dans la classe parente
- Ajout de la gestion des thèmes
- Nouvelle information récupérée lors de l'inventaire "mini", en l'état du thème courant. 
- Les informations sur les unités sont maintenant récupérées lors de l'inventaire "mini" également
- Utilisation des informations d'unité et de thème pour mettre à jour respectivement la configuration accred et du thème. Aucun changement ne sera fait pour ces éléments si on lance avec un inventaire de ce qui existe. Par contre, si l'inventaire vient de WP-Veritas, là, il pourrait y avoir des changements.
- Changement de la manière de "générer" des strings en passant de `"%s ..." % ...` à `"...".format(...)`
