### PR TITLE
Use right version for TinyMCE Advanced

### DIFF
--- a/ansible/roles/wordpress-instance/tasks/plugins.yml
+++ b/ansible/roles/wordpress-instance/tasks/plugins.yml
@@ -125,7 +125,7 @@
     state:
       - symlinked
       - active
-    from: https://downloads.wordpress.org/plugin/tinymce-advanced.5.2.1.zip
+    from: https://github.com/epfl-si/jahia2wp/raw/release2018/data/plugins/generic/tinymce-advanced/tinymce-advanced.5.2.1.zip
 
 - name: Gutenberg PDF Viewer Block
   wordpress_plugin:

--- a/ansible/roles/wordpress-instance/tasks/plugins.yml
+++ b/ansible/roles/wordpress-instance/tasks/plugins.yml
@@ -125,7 +125,7 @@
     state:
       - symlinked
       - active
-    from: wordpress.org/plugins
+    from: https://downloads.wordpress.org/plugin/tinymce-advanced.5.2.1.zip
 
 - name: Gutenberg PDF Viewer Block
   wordpress_plugin:


### PR DESCRIPTION
On s'assure que la version du plugin TinyMCE est la même que dans la PR https://github.com/epfl-si/jahia2wp/pull/1122 car on se basait sur la version qui est dans le store WordPress, donc pas alignée avec ce qu'on installait avec `jahia2wp`. Donc, si on symlinquait le plugin, on passait sur la version de l'image, qui était plus récente et pas 100% compatible avec notre version de WP. Elle "était" plus récente car il semblerait qu'entre temps les développeurs du plugins l'ait supprimée du store WordPress donc ça ne nous impacte pas. Mais pour éviter tout impact, on "force" le ZIP à utiliser pour mettre dans l'image. Et il a été choisi de mettre l'URL du ZIP qui est dans Jahia2WP comme ça si un jour on vire la limitation là, on virera à tous les coups le ZIP et le build de l'image plantera dans Jenkins, ce qui nous "forcera" à aussi mettre à jour l'image.
Référencer plutôt un ZIP donné dans le store WordPress ferait qu'on risque à tous les coups d'oublier de faire le changement aussi dans "wp-ops".
