### PR TITLE
[Feature] More menu monitoring

### DIFF
--- a/docker/monitoring-menus-probe/index.js
+++ b/docker/monitoring-menus-probe/index.js
@@ -76,11 +76,11 @@ async function scrapeExternalMenus (siteUrl, metrics) {
        await fetchJson(siteUrl + '/wp-json/wp/v2/epfl-external-menu'))
   {
     const slug = externalMenu.slug,
-          sync = externalMenu.sync_status || {}
-    metrics.externalMenuSyncLastSuccess.set(
-      {slug}, Number(sync.last_success))
-    metrics.externalMenuSyncFailingSince.set(
-      {slug}, Number(sync.failing_since))
+          sync = externalMenu.sync_status || {},
+          lastSuccess = Number(sync.last_success),
+          failingSince = Number(sync.failing_since)
+    if (lastSuccess)  metrics.externalMenuSyncLastSuccess.set ({slug}, lastSuccess)
+    if (failingSince) metrics.externalMenuSyncFailingSince.set({slug}, failingSince)
   }
 }
 

--- a/docker/monitoring-menus-probe/index.js
+++ b/docker/monitoring-menus-probe/index.js
@@ -34,16 +34,16 @@ async function siteToMetrics(siteUrl) {
     return new prometheus.Gauge({ name, help, labelNames: ['lang'], registers: [r] })
   }
   const metrics = {
-    menuTime: gauge('epfl_menu_request_time_seconds',
-                    'Time in seconds it took to scrape the JSON menu'),
-    menuCount: gauge('epfl_menu_count',
-                     'Number of menu entries that live on this site (not parent nor sub-sites)'),
+    menuTime:        gauge('epfl_menu_request_time_seconds',
+                           'Time in seconds it took to scrape the JSON menu'),
+    menuCount:       gauge('epfl_menu_count',
+                           'Number of menu entries that live on this site (not parent nor sub-sites)'),
     menuCountUnique: gauge('epfl_menu_unique_count',
-                     'Number of unique menu entries that live on this site (not parent nor sub-sites)'),
+                           'Number of unique menu entries that live on this site (not parent nor sub-sites)'),
     menuOrphanCount: gauge('epfl_menu_orphan_count',
-                     'Number of orphan menu entries'),
-    menuCycleCount: gauge('epfl_menu_cycle_count',
-                     'Number of cycles in menu entries'),
+                           'Number of orphan menu entries'),
+    menuCycleCount:  gauge('epfl_menu_cycle_count',
+                           'Number of cycles in menu entries'),
   }
 
   await scrapeMenus(siteUrl, metrics)

--- a/docker/monitoring-menus-probe/index.js
+++ b/docker/monitoring-menus-probe/index.js
@@ -46,15 +46,19 @@ async function siteToMetrics(siteUrl) {
                      'Number of cycles in menu entries'),
   }
 
-  for(let lang of await fetchJson(siteUrl + '/wp-json/epfl/v1/languages')) {
-    await scrapeMenu(siteUrl + '/wp-json/epfl/v1/menus/top?lang=' + lang,
-                     withLabels({lang}, metrics))
-  }
+  await scrapeMenus(siteUrl, metrics)
 
   return r.metrics()
 }
 
-async function scrapeMenu(menuUrl, metrics) {
+async function scrapeMenus (siteUrl, metrics) {
+  for(let lang of await fetchJson(siteUrl + '/wp-json/epfl/v1/languages')) {
+    await scrapeMenu(siteUrl + '/wp-json/epfl/v1/menus/top?lang=' + lang,
+                     withLabels({lang}, metrics))
+  }
+}
+
+async function scrapeMenu (menuUrl, metrics) {
   const end = startTimer()
   let menu = await fetchJson(menuUrl)
   metrics.menuTime.set(end())
@@ -85,7 +89,7 @@ async function scrapeMenu(menuUrl, metrics) {
   metrics.menuCycleCount.set(graphlib.alg.findCycles(g).length)
 }
 
-async function fetchJson(url) {
+async function fetchJson (url) {
   return fetch(url).then((resp) => resp.json())
 }
 
@@ -97,7 +101,7 @@ function getQueue (url) {
   return queues[url]
 }
 
-function startTimer() {
+function startTimer () {
   const now = process.hrtime.bigint()
   return () => {
     const elapsed = process.hrtime.bigint() - now
@@ -106,7 +110,7 @@ function startTimer() {
   }
 }
 
-function withLabels(labels, metrics) {
+function withLabels (labels, metrics) {
   return _.mapValues(metrics, (metric) => {
     const setOrig = metric.set.bind(metric)
     return _.extend({


### PR DESCRIPTION
“Last success” and “failing since” time series, as epoch numbers, per originating URI, menu slug (e.g. `top`, `footer`), and language.

- More work in the prober to scrape the new timeseries
- Work in tandem with https://github.com/epfl-si/wp-plugin-epfl-menus/pull/3 for the labels (with temporary fallback mode, whence only a not-so-helpful menu slug can be computed)