### PR TITLE
Use WPCLI for EPFL-intranet configuration

### DIFF
--- a/ansible/ansible.cfg
+++ b/ansible/ansible.cfg
@@ -1,0 +1,2 @@
+[ssh_connection]
+pipelining = true

--- a/ansible/roles/wordpress-instance/action_plugins/wordpress_wpcli.py
+++ b/ansible/roles/wordpress-instance/action_plugins/wordpress_wpcli.py
@@ -1,0 +1,24 @@
+import sys
+import os.path
+import re
+
+# To be able to include package wp_inventory in parent directory
+sys.path.append(os.path.dirname(__file__))
+
+from wordpress_action_module import WordPressActionModule
+
+
+class ActionModule(WordPressActionModule):
+    def run(self, tmp=None, task_vars=None):
+        
+        self.result = super(ActionModule, self).run(tmp, task_vars)
+
+        # Getting command to execute
+        wpcli_command = str(self._task.args.get('wpcli_command')).strip()
+
+        if wpcli_command != "":
+
+            # Executing command and updating result
+            self._update_result(self._run_wp_cli_action(wpcli_command))
+
+        return self.result

--- a/ansible/roles/wordpress-instance/tasks/plugins.yml
+++ b/ansible/roles/wordpress-instance/tasks/plugins.yml
@@ -191,20 +191,9 @@
       - active
     from: https://github.com/epfl-sti/wordpress.plugin.accred/archive/vpsi.zip
 
-- name: accred administrator group
-  wordpress_option:
-    name: plugin:epfl_accred:administrator_group
-    value: "{{ wp_administrator_group }}"
-
-- name: accred unit name
-  wordpress_option:
-    name: plugin:epfl_accred:unit
-    value: "{{ wp_unit_name }}"
-
-- name: accred unit ID
-  wordpress_option:
-    name: plugin:epfl_accred:unit_id
-    value: "{{ wp_unit_id }}"
+- name: Accred options
+  wordpress_option: "{{ item }}"
+  with_items: "{{ plugin_accred_options }}"
 
 - name: Cache-Control plugin
   wordpress_plugin:
@@ -488,6 +477,10 @@
     state: "{{ plugins_for_inside_category }}"
     from: https://github.com/epfl-si/wp-plugin-epfl-intranet
 
+- name: epfl-intranet status
+  wordpress_wpcli: "{{ item }}"
+  with_items: "{{ plugin_epfl_intranet_wpcli }}"
+    
 - name: epfl-emploi plugin
   wordpress_plugin:
     name: epfl-emploi

--- a/ansible/roles/wordpress-instance/vars/plugin-vars.yml
+++ b/ansible/roles/wordpress-instance/vars/plugin-vars.yml
@@ -22,9 +22,7 @@ plugins_for_cdhshs_category: '{{ [ "symlinked", "active" ] if wp_site_category =
 plugins_for_emploi_category: '{{ [ "symlinked", "active" ] if wp_site_category == "Emploi" else "absent" }}'
 plugins_for_library_category: '{{ [ "symlinked", "active" ] if wp_site_category == "Library" else "absent" }}'
 plugins_for_restauration_category: '{{ [ "symlinked", "active" ] if wp_site_category == "Library" else "absent" }}'
-
-# Category based on environment
-plugins_for_inside_category: '{{ ["symlinked", "active"] if wp_env == "inside" else "absent" }}'
+plugins_for_inside_category: '{{ ["symlinked", "active"] if wp_site_category == "Inside" else "absent" }}'
 
 # Defining if WP is managed or not
 wp_is_managed: "{{ wp_site_category != 'Unmanaged' }}"
@@ -32,10 +30,16 @@ wp_is_managed: "{{ wp_site_category != 'Unmanaged' }}"
 
 #### Plugins Configuration
 
+# EPFL Intranet
+plugin_epfl_intranet_wpcli:
+  - wpcli_command: '{{ "epfl intranet enable-protection" if wp_site_category == "Inside" else "" }}'
+
+
 # Main-WP Child
 plugin_mainwp_child_options:
   - name: mainwp_child_uniqueId
     value: 'WinterIsComing'
+
 
 # Cache Control
 plugin_cache_control_options:
@@ -188,3 +192,12 @@ plugin_svg_support_options:
 plugin_enlighter_options:
   - name: enlighter-options
     value: a:69:{s:19:"translation-enabled";b:1;s:16:"enlighterjs-init";s:6:"inline";s:21:"enlighterjs-assets-js";b:1;s:25:"enlighterjs-assets-themes";b:1;s:34:"enlighterjs-assets-themes-external";b:0;s:26:"enlighterjs-selector-block";s:18:"pre.EnlighterJSRAW";s:27:"enlighterjs-selector-inline";s:19:"code.EnlighterJSRAW";s:18:"enlighterjs-indent";i:4;s:28:"enlighterjs-ampersandcleanup";b:1;s:21:"enlighterjs-linehover";b:1;s:26:"enlighterjs-rawcodedbclick";b:0;s:24:"enlighterjs-textoverflow";s:5:"break";s:23:"enlighterjs-linenumbers";b:1;s:17:"enlighterjs-theme";s:9:"enlighter";s:21:"enlighterjs-retaincss";b:0;s:18:"toolbar-visibility";s:4:"show";s:18:"toolbar-button-raw";b:1;s:19:"toolbar-button-copy";b:1;s:21:"toolbar-button-window";b:1;s:15:"tinymce-backend";b:0;s:16:"tinymce-frontend";b:0;s:15:"tinymce-formats";b:1;s:17:"tinymce-autowidth";b:0;s:22:"tinymce-tabindentation";b:0;s:25:"tinymce-keyboardshortcuts";b:0;s:12:"tinymce-font";s:13:"sourcecodepro";s:16:"tinymce-fontsize";s:5:"0.7em";s:18:"tinymce-lineheight";s:5:"1.4em";s:13:"tinymce-color";s:7:"#000000";s:15:"tinymce-bgcolor";s:7:"#f9f9f9";s:17:"gutenberg-backend";b:1;s:16:"quicktag-backend";b:0;s:17:"quicktag-frontend";b:0;s:13:"quicktag-mode";s:4:"html";s:14:"shortcode-mode";s:8:"disabled";s:16:"shortcode-inline";b:1;s:22:"shortcode-type-generic";b:0;s:23:"shortcode-type-language";b:0;s:20:"shortcode-type-group";b:0;s:24:"shortcode-filter-content";b:1;s:24:"shortcode-filter-excerpt";b:1;s:23:"shortcode-filter-widget";b:0;s:24:"shortcode-filter-comment";b:0;s:31:"shortcode-filter-commentexcerpt";b:0;s:11:"gfm-enabled";b:0;s:10:"gfm-inline";b:1;s:12:"gfm-language";s:3:"raw";s:18:"gfm-filter-content";b:1;s:18:"gfm-filter-excerpt";b:1;s:17:"gfm-filter-widget";b:0;s:18:"gfm-filter-comment";b:0;s:25:"gfm-filter-commentexcerpt";b:0;s:14:"compat-enabled";b:0;s:13:"compat-crayon";b:0;s:12:"compat-type1";b:0;s:12:"compat-type2";b:0;s:21:"compat-filter-content";b:1;s:21:"compat-filter-excerpt";b:1;s:20:"compat-filter-widget";b:0;s:21:"compat-filter-comment";b:0;s:28:"compat-filter-commentexcerpt";b:0;s:12:"cache-custom";b:0;s:10:"cache-path";s:0:"";s:9:"cache-url";s:0:"";s:27:"dynamic-resource-invocation";b:1;s:19:"ext-infinite-scroll";b:0;s:16:"ext-ajaxcomplete";b:0;s:17:"bbpress-shortcode";b:0;s:16:"bbpress-markdown";b:0;}
+
+# Accred
+plugin_accred_options:
+  - name: plugin:epfl_accred:administrator_group
+    value: "{{ wp_administrator_group }}"
+  - name: plugin:epfl_accred:unit
+    value: "{{ wp_unit_name }}"
+  - name: plugin:epfl_accred:unit_id
+    value: "{{ wp_unit_id }}"


### PR DESCRIPTION
- Ajout d'un "ActionPlugin" (notion Ansible) pour pouvoir exécuter des commandes WP-CLI spécifiées dans les fichiers YAML de configuration des plugins, thèmes et autres...
- Suite à PR https://github.com/epfl-si/wp-plugin-epfl-intranet/pull/1, utilisation de WP-CLI pour activer et configurer le plugin `epfl-intranet`. 
L'utilisation de WP-CLI permet de faire en sorte que le fichier `.htaccess` soit correctement modifié lors de l'activation ou désactivation.
- Ajout d'un peu de config Ansible pour augmenter les perfs lors de connexions SSH
- Changement de la manière dont on détermine si on est sur un site "Inside" (on utilise aussi la catégorie au lieu de passer par le WPENV, c'est plus cohérent d'utiliser la même source de données).
- Regroupement des configurations Accred en une seule.
