### PR TITLE
Add mainwp plugin to image

### DIFF
--- a/ansible/roles/wordpress-instance/tasks/plugins.yml
+++ b/ansible/roles/wordpress-instance/tasks/plugins.yml
@@ -511,3 +511,9 @@
     name: epfl-courses-se
     state: "{{ plugins_for_cdhshs_category }}"
     from: https://github.com/epfl-si/jahia2wp/tree/release2018/data/wp/wp-content/plugins/epfl-courses-se
+
+- name: MainWP plugin
+  wordpress_plugin:
+    name: mainwp
+    state: "{{ plugins_for_admin_category }}"
+    from: wordpress.org/plugins

--- a/ansible/roles/wordpress-instance/vars/plugin-vars.yml
+++ b/ansible/roles/wordpress-instance/vars/plugin-vars.yml
@@ -22,6 +22,7 @@ plugins_for_cdhshs_category: '{{ [ "symlinked", "active" ] if wp_site_category =
 plugins_for_emploi_category: '{{ [ "symlinked", "active" ] if wp_site_category == "Emploi" else "absent" }}'
 plugins_for_library_category: '{{ [ "symlinked", "active" ] if wp_site_category == "Library" else "absent" }}'
 plugins_for_restauration_category: '{{ [ "symlinked", "active" ] if wp_site_category == "Library" else "absent" }}'
+plugins_for_admin_category: '{{ [ "symlinked", "active" ] if wp_site_category == "admin" else "absent" }}'
 
 # Category based on environment
 plugins_for_inside_category: '{{ ["symlinked", "active"] if wp_env == "inside" else "absent" }}'


### PR DESCRIPTION
- Ajout d'une catégorie de site "admin" (non présente dans `jahia2wp` mais existante dans WP-Veritas)
- Catégorie utilisée par le site wp-manager.epfl.ch
- Association du plugin "MainWP" à cette catégorie
