### PR TITLE
Fix WP Veritas inventory --check

### DIFF
--- a/ansible/inventory/wp-veritas/wp_veritas_inventory.py
+++ b/ansible/inventory/wp-veritas/wp_veritas_inventory.py
@@ -146,7 +146,7 @@ class Inventory:
         if group in self.groups:
             return
         self.groups.add(group)
-
+        self.inventory.setdefault('all-wordpresses', {}).setdefault('children', []).append(group)
         self.inventory.setdefault(group, {}).setdefault('hosts', [])
 
 

--- a/ansible/roles/wordpress-instance/action_plugins/wordpress_option.py
+++ b/ansible/roles/wordpress-instance/action_plugins/wordpress_option.py
@@ -13,6 +13,11 @@ class ActionModule(WordPressActionModule):
         
         self.result = super(ActionModule, self).run(tmp, task_vars)
 
+        # Handling --check execution mode
+        if task_vars['ansible_check_mode']:
+            self.result['skipped'] = True
+            return self.result
+
         self._update_option()
 
         return self.result

--- a/ansible/roles/wordpress-instance/action_plugins/wordpress_plugin.py
+++ b/ansible/roles/wordpress-instance/action_plugins/wordpress_plugin.py
@@ -19,6 +19,11 @@ class ActionModule(WordPressActionModule):
 
         self.result = super(ActionModule, self).run(tmp, task_vars)
         
+        # Handling --check execution mode
+        if task_vars['ansible_check_mode']:
+            self.result['skipped'] = True
+            return self.result
+
         self._name = self._task.args.get('name')
         self._mandatory = self._task.args.get('is_mu', False)
         self._type = 'mu-plugin' if self._task.args.get('is_mu', False) else 'plugin'

--- a/ansible/roles/wordpress-instance/action_plugins/wordpress_plugin_epfl_intranet.py
+++ b/ansible/roles/wordpress-instance/action_plugins/wordpress_plugin_epfl_intranet.py
@@ -15,6 +15,11 @@ class ActionModule(WordPressActionModule):
         
         self.result = super(ActionModule, self).run(tmp, task_vars)
 
+        # Handling --check execution mode
+        if task_vars['ansible_check_mode']:
+            self.result['skipped'] = True
+            return self.result
+
         # We only can do the job if plugin is installed
         if self._plugin_is_installed():
 

--- a/ansible/roles/wordpress-instance/action_plugins/wordpress_theme.py
+++ b/ansible/roles/wordpress-instance/action_plugins/wordpress_theme.py
@@ -14,6 +14,11 @@ class ActionModule(WordPressActionModule):
     def run(self, tmp=None, task_vars=None):
         self.result = super(ActionModule, self).run(tmp, task_vars)
 
+        # Handling --check execution mode
+        if task_vars['ansible_check_mode']:
+            self.result['skipped'] = True
+            return self.result
+
         self._name = self._task.args.get('name')
         self._type = 'theme'
         self._mandatory = False


### PR DESCRIPTION
Quelques corrections pour que l'option `--check` d'Ansible puisse fonctionner correctement.
- Remise en place de la catégorie `all-wordpresses` qui est référencée dans Ansible
- Ajout de check dans les ActionPlugin pour faire en sorte de détecter si on exécute en mode `--check` et ne rien faire.