### PR TITLE
Fix value of wp_administrator_group

### DIFF
--- a/ansible/roles/wordpress-instance/vars/accred-vars.yml
+++ b/ansible/roles/wordpress-instance/vars/accred-vars.yml
@@ -1,5 +1,5 @@
 # Variables related to EPFL accred system and access control
-wp_administrator_group: WP_SuperAdmin
+wp_administrator_group: WP-SuperAdmin
 
 # This should come from WP-Veritas inventory. If Ansible is run with an "existing sites" inventory,
 # current theme value will be read in database to fill "...["wp_details"]["options"]["plugin:epfl_accred:unit"]" and nothing will change


### PR DESCRIPTION
Après avoir fait des tests avec la commande du genre : 

`./wpsible -l www__labs__mackenziemathis_lab --check --wp-veritas -t configure,plugins,themes,symlink -e '{"wp_destructive": {"www__labs__mackenziemathis_lab": ["config","code"]}, "wp_ensure_symlink_version": "5.2", "wp_is_managed":true}' `

Il semblerait que la valeur de wp_administrator_group n'était pas la bonne