### PR TITLE
[Feature] wp-veritas integration

### DIFF
--- a/ansible/inventory/prod/wordpress-instances
+++ b/ansible/inventory/prod/wordpress-instances
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
-# USAGE:  ./wordpress-instance [--full]
-#           --full : to get all details about each WP instance
+# Ansible inventory script to enumerate all "physically" present
+# WordPress instances on the production NFS share
 
 import sys
 import os
@@ -26,7 +26,6 @@ env_prefix = 'prod'
 # Defining if we have to include all details for WP instances
 include_details = len(sys.argv)> 1 and sys.argv[1] == '--full'
 
-inventory = WPInventory(targets, prune_elements, env_prefix, include_details=include_details)
+inventory = WPInventory(targets, prune_elements, env_prefix)
 
 print(json.dumps(inventory.get_inventory(), sort_keys=True, indent=4))
-

--- a/ansible/inventory/test/wordpress-instances
+++ b/ansible/inventory/test/wordpress-instances
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
-# USAGE:  ./wordpress-instance [--full]
-#           --full : to get all details about each WP instance
+# Ansible inventory script to enumerate all "physically" present
+# WordPress instances on the test NFS share
 
 import sys
 import os
@@ -26,9 +26,6 @@ prune_elements = {
 
 env_prefix = 'test'
 
-# Defining if we have to include all details for WP instances
-include_details = len(sys.argv)> 1 and sys.argv[1] == '--full'
-
-inventory = WPInventory(targets, prune_elements, env_prefix, include_details=include_details)
+inventory = WPInventory(targets, prune_elements, env_prefix)
 
 print(json.dumps(inventory.get_inventory(), sort_keys=True, indent=4))

--- a/ansible/inventory/wp-veritas/wp_veritas_inventory.py
+++ b/ansible/inventory/wp-veritas/wp_veritas_inventory.py
@@ -111,24 +111,11 @@ class Inventory:
 
     def _add(self, site):
 
-        wp_details = {
-            'options' : {
-                'epfl:site_category': site.category,
-                'plugin:epfl_accred:unit_id': site.unit_id,
-                'plugin:epfl_accred:unit': site.unit_name,
-                'stylesheet': site.theme
-            },
-            'polylang': {
-                'langs': site.languages
-            }
-        }
-
         # fulfill vars for the site
         meta_site = {
             "wp_env": site.openshift_env,
             "wp_hostname": site.parsed_url.netloc,
             "wp_path": re.sub(r'^/', '', site.parsed_url.path),
-            "wp_details": wp_details
         }
 
         # Adding more information to site

--- a/ansible/roles/wordpress-instance/lookup_plugins/wpveritas.py
+++ b/ansible/roles/wordpress-instance/lookup_plugins/wpveritas.py
@@ -1,0 +1,80 @@
+# (c) 2020, EPFL IDEV-FSD <idev-fsd@groupes.epfl.ch>
+
+"""Look up desired state in the wp-veritas database.
+
+Usage:
+
+  lookup("wpveritas", "unitId")
+  lookup("wpveritas", "stylesheet")
+  lookup("wpveritas")    # Gives out the entire data structure
+
+Configuration is done through Ansible variables:
+
+`wpveritas_api_url`
+: The URL to fetch the API endpoint from (without the `/v1/sites` suffix)
+`wp_base_url`
+: The URL of the WordPress site to look up
+"""
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+from ansible.errors import AnsibleError
+from ansible.plugins.lookup import LookupBase
+from urllib.request import urlopen    # Python 2? Naah.
+from ssl import SSLContext
+import json
+
+class LookupModule(LookupBase):
+    def run(self, terms, variables, **kwargs):
+        if len(terms) > 1:
+            raise AnsibleError('Usage: lookup("wpveritas", KEY)')
+
+        wpveritas_api_url = self.get_var(variables, 'wpveritas_api_url')
+        wp_site_base_url  = self.get_var(variables, 'wp_base_url')
+
+        wpveritas_state = WpVeritas(wpveritas_api_url).get_site(url=wp_site_base_url)
+
+        if terms:
+            return [wpveritas_state[terms[0]]]
+        else:
+            return [wpveritas_state]
+
+    def get_var(self, variables, var_name):
+        self._templar.available_variables = variables   # Calls an @property.setter
+        variables = self._templar.available_variables   # Calls a getter
+        if var_name not in variables:
+            raise AnsibleError('In order to use lookup("wpveritas", ...), please define variable %s' % var_name)
+        return self._templar.template(variables[var_name], fail_on_undefined=True)
+
+
+class WpVeritas(object):
+    def __init__(self, wpveritas_api_url):
+        self._wpveritas_api_url = wpveritas_api_url
+
+    def get_site(self, url):
+        whole_state = self._get_state(self._wpveritas_api_url)
+        the_site = [s for s in whole_state if s['url'] == url]
+        if len(the_site) == 1:
+            return the_site[0]
+        else:
+            return {}
+
+    _state_cache = {}
+
+    @classmethod
+    def _get_state(cls, wpveritas_api_url):
+        if wpveritas_api_url not in cls._state_cache:
+            cls._state_cache[wpveritas_api_url] = cls._do_fetch(wpveritas_api_url)
+        return cls._state_cache[wpveritas_api_url]
+
+    @classmethod
+    def _do_fetch(cls, wpveritas_api_url):
+
+        if "nip.io" in wpveritas_api_url:
+            context = SSLContext(verify=False)
+        else:
+            context = None
+
+        with urlopen(wpveritas_api_url + '/v1/sites', context=context) as url:
+            return json.loads(url.read().decode())

--- a/ansible/roles/wordpress-instance/vars/accred-vars.yml
+++ b/ansible/roles/wordpress-instance/vars/accred-vars.yml
@@ -2,7 +2,5 @@
 wp_administrator_group: WP-SuperAdmin
 
 # This should come from WP-Veritas inventory. If Ansible is run with an "existing sites" inventory,
-# current theme value will be read in database to fill "...["wp_details"]["options"]["plugin:epfl_accred:unit"]" and nothing will change
-# Using WP-Veritas inventory, value will be correct
-wp_unit_name: '{{ hostvars[inventory_hostname]["wp_details"]["options"]["plugin:epfl_accred:unit"] }}'
-wp_unit_id: '{{ hostvars[inventory_hostname]["wp_details"]["options"]["plugin:epfl_accred:unit_id"] }}'
+wp_unit_name: '{{ lookup("wpveritas", "unitName") }}'
+wp_unit_id: '{{ lookup("wpveritas", "unitId") }}'

--- a/ansible/roles/wordpress-instance/vars/main.yml
+++ b/ansible/roles/wordpress-instance/vars/main.yml
@@ -45,3 +45,8 @@ wp_plugin_list: "{{ ansible_facts.ansible_local.wp_plugin_list }}"
 wp_ops_rpcclient_ipv4_range: 10.180.21.0/24
 
 wp_use_gutenberg: '{{ wp_ensure_symlink_version is defined and (wp_ensure_symlink_version | float) >= 5.0 }}'
+
+wpveritas_api_url: '{{ _wpveritas_servers[openshift_namespace] }}'
+_wpveritas_servers:
+  wwp: https://wp-veritas.epfl.ch/api
+  wwp-test: https://wp-veritas.128.178.222.83.nip.io/api

--- a/ansible/roles/wordpress-instance/vars/plugin-vars.yml
+++ b/ansible/roles/wordpress-instance/vars/plugin-vars.yml
@@ -15,7 +15,7 @@ plugins_use_gutenberg: "{{ wp_use_gutenberg }}"
 # managing their active / inactive state.
 # We use information recovered by inventory to determine site category
 # https://docs.ansible.com/ansible/latest/user_guide/playbooks_variables.html
-wp_site_category: '{{ hostvars[inventory_hostname]["wp_details"]["options"]["epfl:site_category"] }}'
+wp_site_category: '{{ lookup("wpveritas", "category") }}'
 
 # Defining plugin state for each category
 plugins_for_cdhshs_category: '{{ [ "symlinked", "active" ] if wp_site_category == "CDHSHS" else "absent" }}'

--- a/ansible/roles/wordpress-instance/vars/theme-vars.yml
+++ b/ansible/roles/wordpress-instance/vars/theme-vars.yml
@@ -1,9 +1,6 @@
 # Theme variables go here
 
-# This should come from WP-Veritas inventory. If Ansible is run with an "existing sites" inventory,
-# current theme value will be read in database to fill "wp_details.options.stylesheet" and nothing will change
-# Using WP-Veritas inventory, value will be correct
-theme_name: '{{ hostvars[inventory_hostname]["wp_details"]["options"]["stylesheet"] }}'
+theme_name: '{{ lookup("wpveritas", "theme") }}'
 
 
 ### 2018 Themes

--- a/ansible/wpsible
+++ b/ansible/wpsible
@@ -85,6 +85,11 @@ while [ "$#" -gt 0 ]; do
     esac
 done
 
+# https://github.com/ansible/ansible/issues/32499, https://bugs.python.org/issue35219
+case "$(uname -s)" in
+    Darwin) export OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES ;;
+esac
+
 set -e
 
 case "$mode" in


### PR DESCRIPTION
- New `lookup("wpveritas")` lookup plug-in
- Use it to look up `wp_unit_name`, `wp_unit_id`, `wp_site_category` and `theme_name` from the authoritative source
- Stop trying to gather surrogates for these values at inventory time, thereby bringing back acceptable performance to the `wpsible` inventory phase
