### PR TITLE
Refactor classes in wordpress_action_module

### DIFF
--- a/ansible/roles/wordpress-instance/action_plugins/wordpress_action_module.py
+++ b/ansible/roles/wordpress-instance/action_plugins/wordpress_action_module.py
@@ -124,13 +124,6 @@ class WordPressActionModule(ActionBase):
                                       module_args=args, tmp=self._tmp,
                                       task_vars=self._task_vars)
 
-        # If command was to update an option using WP CLI
-        if '_raw_params' in args and re.match(r'^wp\s--path=(.+)\soption\supdate', args['_raw_params']):
-            # We update 'changed' key depending on what was done by WPCLI
-            # NOTE: For an unknown reason, for some options, even if we set 'changed' to False
-            # when nothing is changed, somewhere, the value is changed to True... !?!
-            result['changed'] = not result['stdout'].endswith('option is unchanged.')
-
         if update_result:
             self._update_result(result)
             return self.result

--- a/ansible/roles/wordpress-instance/action_plugins/wordpress_option.py
+++ b/ansible/roles/wordpress-instance/action_plugins/wordpress_option.py
@@ -2,7 +2,7 @@ import sys
 import os.path
 import re
 
-# To be able to include package wp_inventory in parent directory
+# To be able to import wordpress_action_module
 sys.path.append(os.path.dirname(__file__))
 
 from wordpress_action_module import WordPressActionModule

--- a/ansible/roles/wordpress-instance/action_plugins/wordpress_option.py
+++ b/ansible/roles/wordpress-instance/action_plugins/wordpress_option.py
@@ -49,8 +49,9 @@ class ActionModule(WordPressActionModule):
             if option_value != '':
                 json_format = '--format=json'
 
+        changed_status_orig = self.result['changed']
         cmd = "option update {} {} '{}' --skip-themes --skip-plugins".format(json_format, self._task.args.get('name'), option_value)
+        result = self._run_wp_cli_action(cmd)
 
-        return self._run_wp_cli_action(cmd)
-
-    
+        if 'option is unchanged.' in result.stdout:
+            self.result['changed'] = changed_status_orig

--- a/ansible/roles/wordpress-instance/action_plugins/wordpress_plugin.py
+++ b/ansible/roles/wordpress-instance/action_plugins/wordpress_plugin.py
@@ -12,9 +12,9 @@ sys.path.append(os.path.dirname(__file__))
 
 from ansible.errors import AnsibleActionFail
 from ansible.module_utils import six
-from wordpress_action_module import WordPressActionModule
+from wordpress_action_module import WordPressPluginOrThemeActionModule
 
-class ActionModule(WordPressActionModule):
+class ActionModule(WordPressPluginOrThemeActionModule):
     def run (self, tmp=None, task_vars=None):
 
         self.result = super(ActionModule, self).run(tmp, task_vars)

--- a/ansible/roles/wordpress-instance/action_plugins/wordpress_plugin.py
+++ b/ansible/roles/wordpress-instance/action_plugins/wordpress_plugin.py
@@ -7,7 +7,7 @@ import sys
 import os.path
 import json
 
-# To be able to include package wp_inventory in parent directory
+# To be able to import wordpress_action_module
 sys.path.append(os.path.dirname(__file__))
 
 from ansible.errors import AnsibleActionFail

--- a/ansible/roles/wordpress-instance/action_plugins/wordpress_plugin_epfl_intranet.py
+++ b/ansible/roles/wordpress-instance/action_plugins/wordpress_plugin_epfl_intranet.py
@@ -4,7 +4,7 @@ import os.path
 # There is a name clash with a module in Ansible named "copy":
 deepcopy = __import__('copy').deepcopy
 
-# To be able to include package wp_inventory in parent directory
+# To be able to import wordpress_action_module
 sys.path.append(os.path.dirname(__file__))
 
 from wordpress_action_module import WordPressActionModule

--- a/ansible/roles/wordpress-instance/action_plugins/wordpress_theme.py
+++ b/ansible/roles/wordpress-instance/action_plugins/wordpress_theme.py
@@ -8,9 +8,9 @@ import os.path
 # To be able to include package wp_inventory in parent directory
 sys.path.append(os.path.dirname(__file__))
 
-from wordpress_action_module import WordPressActionModule
+from wordpress_action_module import WordPressPluginOrThemeActionModule
 
-class ActionModule(WordPressActionModule):
+class ActionModule(WordPressPluginOrThemeActionModule):
     def run(self, tmp=None, task_vars=None):
         self.result = super(ActionModule, self).run(tmp, task_vars)
 

--- a/ansible/roles/wordpress-instance/action_plugins/wordpress_theme.py
+++ b/ansible/roles/wordpress-instance/action_plugins/wordpress_theme.py
@@ -5,7 +5,7 @@ deepcopy = __import__('copy').deepcopy
 import sys
 import os.path
 
-# To be able to include package wp_inventory in parent directory
+# To be able to import wordpress_action_module
 sys.path.append(os.path.dirname(__file__))
 
 from wordpress_action_module import WordPressPluginOrThemeActionModule


### PR DESCRIPTION
Split huge `WordPressActionModule` class in two

- `WordPressActionModule` knows about symlinks, rimrafs, and WordPress paths and commands
- `WordPressPluginOrThemeActionModule` additionally knows about plugin
  or theme enumeration / activation / deactivation, as well as
  `._name`, `._type` and `._mandatory`
- Move "option is unchanged." behavior into the right subclass
