### PR TITLE
[Fix] Inventory hostvars for WordPress sites

### DIFF
--- a/ansible/inventory/wp-veritas/wp_veritas_inventory.py
+++ b/ansible/inventory/wp-veritas/wp_veritas_inventory.py
@@ -20,10 +20,6 @@ from urllib.parse import urlparse
 import requests
 from six.moves.urllib.parse import urlparse, quote
 
-constant_props = {
-    'openshift_namespace': 'wwp-prod'
-}
-
 class WpVeritasSite:
     WP_VERITAS_SITES_API_URL = 'https://wp-veritas.epfl.ch/api/v1/sites/'
     VERIFY_SSL = True
@@ -121,13 +117,17 @@ class Inventory:
             "wp_env": site.openshift_env,
             "wp_hostname": site.parsed_url.netloc,
             "wp_path": re.sub(r'^/', '', site.parsed_url.path),
+            "openshift_namespace": self._openshift_namespace()
         }
 
         # Adding more information to site
-        meta_site = {**meta_site, **constant_props, **self._connection_props()}
+        meta_site.update(self._connection_props())
 
         self.inventory['_meta']['hostvars'][site.instance_name] = meta_site
         self._add_site_to_group(site, site.openshift_env)
+
+    def _openshift_namespace(self):
+        return 'wwp-prod'
 
     def _add_site_to_group(self, site, openshift_env):
         group = 'prod-{}'.format(openshift_env)

--- a/ansible/inventory/wp-veritas/wp_veritas_inventory.py
+++ b/ansible/inventory/wp-veritas/wp_veritas_inventory.py
@@ -103,7 +103,7 @@ class WpVeritasSite:
             return { 'ansible_connection': 'local' }
         else:
             return {
-                'ansible_host': 'ssh-wwp.epfl.ch',
+                'ansible_host': self._mgmt_ssh_host,
                 'ansible_port': '32222',
                 'ansible_python_interpreter': '/usr/bin/python3',
                 'ansible_user': 'www-data'
@@ -112,6 +112,10 @@ class WpVeritasSite:
     @property
     def _openshift_namespace(self):
         return 'wwp-prod'
+
+    @property
+    def _mgmt_ssh_host(self):
+        return 'ssh-wwp.epfl.ch'
 
 
 class WpVeritasTestSite(WpVeritasSite):

--- a/ansible/inventory/wp-veritas/wp_veritas_inventory.py
+++ b/ansible/inventory/wp-veritas/wp_veritas_inventory.py
@@ -111,7 +111,7 @@ class WpVeritasSite:
 
     @property
     def _openshift_namespace(self):
-        return 'wwp-prod'
+        return 'wwp'
 
     @property
     def _mgmt_ssh_host(self):
@@ -125,6 +125,14 @@ class WpVeritasTestSite(WpVeritasSite):
     @property
     def instance_name(self):
         return 'test_' + super().instance_name
+
+    @property
+    def _openshift_namespace(self):
+        return 'wwp-test'
+
+    @property
+    def _mgmt_ssh_host(self):
+        return 'test-ssh-wwp.epfl.ch'
 
 
 class Inventory:

--- a/ansible/inventory/wp-veritas/wp_veritas_inventory.py
+++ b/ansible/inventory/wp-veritas/wp_veritas_inventory.py
@@ -21,7 +21,6 @@ import requests
 from six.moves.urllib.parse import urlparse, quote
 
 constant_props = {
-    'wp_ensure_symlink_version': '5.2',
     'openshift_namespace': 'wwp-prod'
 }
 

--- a/ansible/inventory/wp_inventory.py
+++ b/ansible/inventory/wp_inventory.py
@@ -150,8 +150,7 @@ class WPInventory():
         
         retval = {
             'ansible_python_interpreter': '/usr/bin/python3',
-            'openshift_namespace': 'wwp-{}'.format(self._env_prefix),
-            'wp_ensure_symlink_version': '5.2'
+            'openshift_namespace': 'wwp-{}'.format(self._env_prefix)
         }
         
         for key, val in wp.items():

--- a/ansible/roles/wordpress-instance/vars/main.yml
+++ b/ansible/roles/wordpress-instance/vars/main.yml
@@ -37,6 +37,9 @@ wp_plugin_list: "{{ ansible_facts.ansible_local.wp_plugin_list }}"
 # particular, to Tequila)
 wp_ops_rpcclient_ipv4_range: 10.180.21.0/24
 
+# What version of WordPress we install.
+wp_ensure_symlink_version: "5.2"
+
 wp_use_gutenberg: '{{ wp_ensure_symlink_version is defined and (wp_ensure_symlink_version | float) >= 5.0 }}'
 
 wpveritas_api_url: '{{ _wpveritas_servers[openshift_namespace] }}'


### PR DESCRIPTION
- `wp_ensure_symlink_version` needs not be a per-host variable anymore
- `openshift_namespace` was unconditionally wrong
- `ansible_host` was wrong on test instances

And refactoring to go with it.
