### PR TITLE
Disable ssh X11 forwarding on the mgmt container

### DIFF
--- a/docker/mgmt/Dockerfile
+++ b/docker/mgmt/Dockerfile
@@ -27,6 +27,7 @@ RUN mkdir /var/run/sshd && \
     sed -ri 's/UsePAM yes/UsePAM no/g' /etc/ssh/sshd_config && \
     sed -ri 's/AcceptEnv LANG LC_\*/AcceptEnv LANG LC_\* WP_ENV/g' /etc/ssh/sshd_config && \
     sed -ri 's/#UsePrivilegeSeparation sandbox/UsePrivilegeSeparation no/g'  /etc/ssh/sshd_config && \
+    sed -ri 's/#?X11Forwarding\s+.*/X11Forwarding no/g' /etc/ssh/sshd_config && \
     mkdir /tmp/openshift && \
     cd /tmp/openshift && \
     curl -L -O https://github.com/openshift/origin/releases/download/v3.10.0/openshift-origin-client-tools-v3.10.0-dd10d17-linux-64bit.tar.gz && \


### PR DESCRIPTION
This works around (speeds up) a possible bad configuration in the client. There is no X11 support whatsoever in the mgmt image.