### PR TITLE
[Fix] AWX in production; AWX dump and restore

### DIFF
--- a/ansible/roles/awx-instance/filter_plugins/imagestream_tag_map.py
+++ b/ansible/roles/awx-instance/filter_plugins/imagestream_tag_map.py
@@ -1,0 +1,26 @@
+import json
+from ansible.module_utils import six
+
+class FilterModule(object):
+    '''
+    custom jinja2 filter to extract the current versions of an ImageStream as a dict.
+    '''
+
+    def filters(self):
+        return {
+            'imagestream_tag_map': self.imagestream_tag_map
+        }
+
+    def imagestream_tag_map(self, struct):
+        if isinstance(struct, six.string_types):
+            struct = json.loads(struct)
+        return dict([u['tag'], self._get_latest_version(u)] for u in struct.get('status', {}).get('tags', []))
+
+    def _get_latest_version(self, u):
+        try:
+            return u['items'][0]['image']
+        except KeyError:
+            return None
+        except IndexError:
+            return None
+

--- a/ansible/roles/awx-instance/handlers/main.yml
+++ b/ansible/roles/awx-instance/handlers/main.yml
@@ -1,3 +1,13 @@
-- name: Restart AWX container
+- name: Restart AWX pod
   delegate_to: localhost
-  shell: "oc -n {{ ansible_oc_namespace }} delete pod awx-0"
+  shell:
+    cmd: |
+      set -e -x
+      oc -n {{ ansible_oc_namespace }} delete pod awx-0
+      for wait in $(seq 1 60); do
+        if oc -n {{ ansible_oc_namespace }} describe pod awx-0 |grep 'Status: *Running'; then
+          break
+        else
+          sleep 2
+        fi
+      done

--- a/ansible/roles/awx-instance/tasks/k8s-builds.yml
+++ b/ansible/roles/awx-instance/tasks/k8s-builds.yml
@@ -28,7 +28,7 @@
 
 - name: "Rebuild {{ awx_runner_image_name }} now"
   when: _awx_runner_buildconfig is changed
-  shell: "oc -n {{ awx_mgmt_build_namespace }} start-build {{ awx_runner_image_name }}"
+  shell: "oc -n {{ awx_build_namespace }} start-build {{ awx_runner_image_name }}"
   delegate_to: localhost
 
 - name: "Patch {{ awx_task_base_image_fullname }} into {{ awx_task_image_name }}"
@@ -48,5 +48,5 @@
 
 - name: "Rebuild {{ awx_task_image_name }} now"
   when: _awx_task_buildconfig is changed
-  shell: "oc -n {{ awx_mgmt_build_namespace }} start-build {{ awx_task_image_name }}"
+  shell: "oc -n {{ awx_build_namespace }} start-build {{ awx_task_image_name }}"
   delegate_to: localhost

--- a/ansible/roles/awx-instance/tasks/k8s-images.yml
+++ b/ansible/roles/awx-instance/tasks/k8s-images.yml
@@ -22,4 +22,4 @@
              {{ ansible_oc_namespace }}/{{ awx_task_image_name }}:{{ awx_version }}
   register: _awx_oc_tag
   changed_when: _awx_task_current_tag not in _awx_oc_tag.stdout
-  notify: Restart AWX container
+  notify: Restart AWX pod

--- a/ansible/roles/awx-instance/tasks/k8s-images.yml
+++ b/ansible/roles/awx-instance/tasks/k8s-images.yml
@@ -1,0 +1,25 @@
+# Sync Docker images built in test into production
+
+- include_vars: k8s-vars.yml
+
+- name: "Get current version of {{ awx_task_image_name }} in {{ ansible_oc_namespace }}"
+  delegate_to: localhost
+  changed_when: false
+  shell:
+    cmd: |
+      oc get -o json -n {{ ansible_oc_namespace }} imagestream {{ awx_task_image_name }}
+  register: _awx_task_imagestream
+
+- set_fact:
+    _awx_task_current_tag: |-
+      {{ (_awx_task_imagestream.stdout | imagestream_tag_map).get(awx_version, "__NONE__") }}
+
+- name: "Promote {{ awx_task_image_name }} to {{ ansible_oc_namespace }}"
+  delegate_to: localhost
+  shell:
+    cmd: |
+      oc tag  {{ awx_build_namespace }}/{{ awx_task_image_name }}:{{ awx_version }} \
+             {{ ansible_oc_namespace }}/{{ awx_task_image_name }}:{{ awx_version }}
+  register: _awx_oc_tag
+  changed_when: _awx_task_current_tag not in _awx_oc_tag.stdout
+  notify: Restart AWX container

--- a/ansible/roles/awx-instance/tasks/k8s.yml
+++ b/ansible/roles/awx-instance/tasks/k8s.yml
@@ -38,7 +38,7 @@
       awx_settings: "{{ lookup('template', 'awx-settings.py') }}"
       nginx_conf: "{{ lookup('template', 'nginx.conf') }}"
       redis_conf: "{{ lookup('template', 'redis.conf') }}"
-  notify: Restart AWX container
+  notify: Restart AWX pod
 
 - name: Ansible Tower secret (awx-secrets)
   openshift:
@@ -54,7 +54,7 @@
       credentials_py: "{{ lookup('template', 'credentials.py.j2') | b64encode }}"
       django_secret_key: "{{ django_secret_key | eyaml(eyaml_keys) | b64encode }}"
       pg_password: "{{ awx_postgresql_database['password'] | eyaml(eyaml_keys)  | b64encode }}"
-  notify: Restart AWX container
+  notify: Restart AWX pod
 
 - name: awx service account
   openshift:
@@ -217,7 +217,7 @@
             emptyDir: {}
           - name: awx-memcached-socket
             emptyDir: {}
-  notify: Restart AWX container
+  notify: Restart AWX pod
 
 - meta: flush_handlers
 

--- a/ansible/roles/awx-instance/tasks/main.yml
+++ b/ansible/roles/awx-instance/tasks/main.yml
@@ -7,7 +7,7 @@
     - awx.openshift
 
 - name: "Ansible Tower images and build configs"
-  when: "ansible_oc_namespace == awx_mgmt_build_namespace"
+  when: "ansible_oc_namespace == awx_build_namespace"
   import_tasks: k8s-builds.yml
   delegate_to: localhost
   tags:

--- a/ansible/roles/awx-instance/tasks/main.yml
+++ b/ansible/roles/awx-instance/tasks/main.yml
@@ -1,11 +1,3 @@
-- name: "Ansible Tower OpenShift objects"
-  import_tasks: k8s.yml
-  delegate_to: localhost
-  tags:
-    - awx
-    - awx.k8s
-    - awx.openshift
-
 - name: "Ansible Tower images and build configs"
   when: "ansible_oc_namespace == awx_build_namespace"
   import_tasks: k8s-builds.yml
@@ -13,6 +5,14 @@
   tags:
     - awx
     - awx.build
+
+- name: "Ansible Tower OpenShift objects"
+  import_tasks: k8s.yml
+  delegate_to: localhost
+  tags:
+    - awx
+    - awx.k8s
+    - awx.openshift
 
 - name: "Ansible Tower database operations"
   include_tasks: ops.yml

--- a/ansible/roles/awx-instance/tasks/main.yml
+++ b/ansible/roles/awx-instance/tasks/main.yml
@@ -1,10 +1,18 @@
-- name: "Ansible Tower images and build configs"
+- name: "Ansible Tower images and build configs on {{ awx_build_namespace }}"
   when: "ansible_oc_namespace == awx_build_namespace"
   import_tasks: k8s-builds.yml
   delegate_to: localhost
   tags:
     - awx
     - awx.build
+
+- name: "Ansible Tower images promoted from {{ awx_build_namespace }}"
+  when: "ansible_oc_namespace != awx_build_namespace"
+  import_tasks: k8s-images.yml
+  delegate_to: localhost
+  tags:
+    - awx
+    - awx.images
 
 - name: "Ansible Tower OpenShift objects"
   import_tasks: k8s.yml

--- a/ansible/roles/awx-instance/tasks/ops.yml
+++ b/ansible/roles/awx-instance/tasks/ops.yml
@@ -1,30 +1,50 @@
 # The tasks in this directory are *not* loaded or run, unless their specific
 # tag is mentioned on the command line.
 
-- name: Dump Ansible Tower database
-  tags: awx.dump
-  connection: local
-  shell: |
-    set -e -x
-    cd ..   # Out of .interactive-playbooks
-    [ -d state/awx ] || mkdir -p state/awx 2>/dev/null
-    oc exec -c awx-web -n {{ ansible_oc_namespace }} awx-0 -- \
-         awx-manage dumpdata --indent=4 --natural-primary --natural-foreign \
-         > state/awx/awx-{{ansible_oc_namespace}}.djangodump
-    # belt *and* suspenders:
-    oc exec -c awx-web -n {{ ansible_oc_namespace }} awx-0 -- \
-        bash -c '. /etc/tower/conf.d/environment.sh; PGPASSWORD="$DATABASE_PASSWORD" pg_dump -c -U "$DATABASE_USER" -d "$DATABASE_NAME" -h "$DATABASE_HOST" -p "$DATABASE_PORT"' \
-        > state/awx/awx-{{ansible_oc_namespace}}.sql
+- include_vars: ops-vars.yml
+  tags:
+    - awx.dump
+    - awx.restore
 
-- name: Restore Ansible Tower database
+- name: "Create {{ ops_state_dir }}"
+  delegate_to: localhost
+  tags: awx.dump
+  file:
+    path: "{{ ops_state_dir }}"
+    state: directory
+
+- name: Dump Ansible Tower database (SQL dump)
+  tags: awx.dump
+  delegate_to: localhost
+  shell:
+    cmd: |
+      oc exec {{ ops_oc_exec_args }} -- bash -c '
+        eval $({{ lookup('template', 'pg_env.sh') }})
+        export PGPASSWORD="$DATABASE_PASSWORD"
+        pg_dump -c -U "$DATABASE_USER" -d "$DATABASE_NAME" -h "$DATABASE_HOST" -p "$DATABASE_PORT"
+      ' > {{ ops_sql_backup }}
+
+# Belt *and* suspenders:
+- name: Dump Ansible Tower database (Django dump)
+  tags: awx.dump
+  delegate_to: localhost
+  shell:
+    cmd: |
+      oc exec {{ ops_oc_exec_args }} -- \
+         awx-manage dumpdata --indent=4 --natural-primary --natural-foreign \
+         > {{ ops_django_backup }}
+
+- name: Restore Ansible Tower database from the SQL dump
   tags: awx.restore
-  connection: local
-  shell: |
-    set -e -x
-    cd ..   # Out of .interactive-playbooks
-    [ -d state/awx ] || mkdir -p state/awx 2>/dev/null
-    # TODO: we would like to restore from the .djangodump instead; unfortunately it raises django.db.utils.IntegrityError
-    # (presumably because the model-level integrity constraints were not applied timely).
-    oc exec -i -c awx-web -n {{ ansible_oc_namespace }} awx-0 -- \
-        bash -c '. /etc/tower/conf.d/environment.sh; PGPASSWORD="$DATABASE_PASSWORD" psql -U "$DATABASE_USER" -d "$DATABASE_NAME" -h "$DATABASE_HOST" -p "$DATABASE_PORT"' \
-        < state/awx/awx-{{ ansible_oc_namespace }}.sql
+  delegate_to: localhost
+  # TODO: we would like to be able to restore from the Django dump
+  # instead (or in addition); unfortunately the current data set
+  # causes django.db.utils.IntegrityError (presumably because the
+  # model-level integrity constraints were not applied timely).
+  shell:
+    cmd: |
+      oc exec -i {{ ops_oc_exec_args }} -- bash -c '
+        eval $({{ lookup('template', 'pg_env.sh') }})
+        export PGPASSWORD="$DATABASE_PASSWORD"
+        psql -U "$DATABASE_USER" -d "$DATABASE_NAME" -h "$DATABASE_HOST" -p "$DATABASE_PORT"
+      ' < {{ ops_sql_backup }}

--- a/ansible/roles/awx-instance/templates/pg_env.sh
+++ b/ansible/roles/awx-instance/templates/pg_env.sh
@@ -1,0 +1,21 @@
+{# Canned shell command to extract the Django database secrets using
+ # Python,and output them to stdout as environment variables in Bourne
+ # Shell format
+ #}
+{% set python_script = '
+import subprocess
+import shlex
+from credentials import DATABASES
+
+pg = DATABASES["default"]
+
+for k in ["NAME", "HOST", "PORT", "USER", "PASSWORD"]:
+    print("DATABASE_%s=%s" % (k, shlex.quote(pg[k])))
+
+' %}
+{# Canned command may not contain single quotes, lest it be
+ # munged by the local shell (which we can't just bypass, because
+ # we need stdin / stdout redirection).
+ #}
+{% set python_script_quoted = python_script | regex_replace('"', '\\\\"') %}
+env PYTHONPATH=/etc/tower/conf.d {{ ansible_python_interpreter }} -c "{{ python_script_quoted }}"

--- a/ansible/roles/awx-instance/vars/main.yml
+++ b/ansible/roles/awx-instance/vars/main.yml
@@ -18,5 +18,5 @@ awx_template_jobs_playbook: "ansible/playbooks/wordpress-main.yml"
 awx_template_jobs_verbosity: 0
 
 # The namespace we build in (and consume build images from).
-# ../tasks/runner.yml is only applied in this namespace.
-awx_mgmt_build_namespace: wwp-test
+# ../tasks/k8s-build.yml is only applied in this namespace.
+awx_build_namespace: wwp-test

--- a/ansible/roles/awx-instance/vars/ops-vars.yml
+++ b/ansible/roles/awx-instance/vars/ops-vars.yml
@@ -1,0 +1,9 @@
+# Variables for ../tasks/ops.yml
+
+# Canned subcommand to run something on the awx-0 container
+ops_oc_exec_args: "-c awx-web -n {{ ansible_oc_namespace }} awx-0"
+
+# Where backups take place (relative to the main playbook)
+ops_state_dir: ../state/awx
+ops_sql_backup: "{{ ops_state_dir }}/awx-{{ ansible_oc_namespace }}.sql"
+ops_django_backup: "{{ ops_state_dir }}/awx-{{ ansible_oc_namespace }}.djangodump"


### PR DESCRIPTION
Previously:

- AWX was not working in production, because it lacked an image for `wp-awx-task` which is only being built in the test namespace;
- the AWX backup and restore operations (`-t awx.dump` and `-t awx.restore` in [`roles/awx-instance/tasks/ops.yml`](https://github.com/epfl-si/wp-ops/blob/master/ansible/roles/awx-instance/tasks/ops.yml)) were broken, because `/etc/tower/conf.d/environment.sh` went away with RabbitMQ.
