### PR TITLE
[fix] Another KeyError hazard

### DIFF
--- a/ansible/roles/wordpress-instance/action_plugins/wordpress_facts.py
+++ b/ansible/roles/wordpress-instance/action_plugins/wordpress_facts.py
@@ -57,7 +57,7 @@ class ActionModule(WordPressActionModule):
 
     def _is_wp_installed (self):
         stat = self._stat('wp-config.php')
-        return stat['stat']['exists']
+        return ('stat' in stat) and (stat['stat']['exists'])
 
     def _is_wp_symlinked (self):
         stat = self._stat('wp-admin')


### PR DESCRIPTION
Defensive programming for when the `wp-config.php` file doesn't exist
