### PR TITLE
[fix] `--check` mode for `-t plugins,themes`

### DIFF
--- a/ansible/roles/wordpress-instance/action_plugins/wordpress_plugin.py
+++ b/ansible/roles/wordpress-instance/action_plugins/wordpress_plugin.py
@@ -18,11 +18,6 @@ class ActionModule(WordPressPluginOrThemeActionModule):
     def run (self, tmp=None, task_vars=None):
 
         self.result = super(ActionModule, self).run(tmp, task_vars)
-        
-        # Handling --check execution mode
-        if task_vars['ansible_check_mode']:
-            self.result['skipped'] = True
-            return self.result
 
         self._name = self._task.args.get('name')
         self._mandatory = self._task.args.get('is_mu', False)

--- a/ansible/roles/wordpress-instance/action_plugins/wordpress_theme.py
+++ b/ansible/roles/wordpress-instance/action_plugins/wordpress_theme.py
@@ -14,11 +14,6 @@ class ActionModule(WordPressPluginOrThemeActionModule):
     def run(self, tmp=None, task_vars=None):
         self.result = super(ActionModule, self).run(tmp, task_vars)
 
-        # Handling --check execution mode
-        if task_vars['ansible_check_mode']:
-            self.result['skipped'] = True
-            return self.result
-
         self._name = self._task.args.get('name')
         self._type = 'theme'
         self._mandatory = False

--- a/ansible/roles/wordpress-instance/tasks/main.yml
+++ b/ansible/roles/wordpress-instance/tasks/main.yml
@@ -77,7 +77,7 @@
       tags: ["config"]
 
 - name: Set up plugins
-  when: wp_can.configure
+  when: wp_can.configure or ansible_check_mode
   tags:
     - plugins
   include_tasks:
@@ -86,7 +86,7 @@
       tags: ["plugins"]
 
 - name: Set up themes
-  when: wp_can.configure
+  when: wp_can.configure or ansible_check_mode
   tags:
     - themes
   include_tasks:

--- a/ansible/roles/wordpress-instance/tasks/plugins.yml
+++ b/ansible/roles/wordpress-instance/tasks/plugins.yml
@@ -8,7 +8,7 @@
 
 - include_vars: wp-destructive.yml   # For wp_can
 - assert:
-    that: wp_can.configure
+    that: wp_can.configure or ansible_check_mode
 
 
 - include_vars: "{{ item }}"

--- a/ansible/roles/wordpress-instance/tasks/themes.yml
+++ b/ansible/roles/wordpress-instance/tasks/themes.yml
@@ -1,6 +1,6 @@
 - include_vars: wp-destructive.yml   # For wp_can
 - assert:
-    that: wp_can.configure
+    that: wp_can.configure or ansible_check_mode
 
 - include_vars: theme-vars.yml
 


### PR DESCRIPTION
- Remove all short-circuit code that was turning --check's into skip's

- Plumb an optional `also_in_check_mode` parameter down the whole
`wordpress_action_module.py`

- Tell Ansible to go ahead with shell commands when this parameter is set

Note that this is independent from the `update_result=` data flow, so one could theoretically use a *destructive* command in check mode, and still check orange / green correctly. (Not suggesting that one *should*)