### PR TITLE
[feature] Adopt ansible.suitcase

### DIFF
--- a/ansible/.gitignore
+++ b/ansible/.gitignore
@@ -1,0 +1,1 @@
+ansible-deps-cache

--- a/ansible/wpsible
+++ b/ansible/wpsible
@@ -41,17 +41,12 @@ fatal () {
 }
 
 platform_check () {
-    test -d /keybase/team || warn <<NO_KEYBASE
-
-WARNING: keybase is not installed, cannot decipher and push secrets.
-
-NO_KEYBASE
-
-    which eyaml >/dev/null || warn <<NO_EYAML
-
-WARNING: eyaml is not installed, cannot decipher and push secrets.
-
-NO_EYAML
+    if ! test -f ansible-deps-cache/.versions 2>/dev/null; then
+        curl https://raw.githubusercontent.com/epfl-si/ansible.suitcase/master/install.sh | \
+            SUITCASE_DIR=$PWD/ansible-deps-cache SUITCASE_ANSIBLE_REQUIREMENTS=requirements.yml sh -x
+    fi
+    export PATH="$PWD/ansible-deps-cache/bin:$PATH"
+    export ANSIBLE_ROLES_PATH="$PWD/ansible-deps-cache/roles"
 }
 
 inventory_mode="test"


### PR DESCRIPTION
We will never have to worry about versions of Python, Ansible, Ansible Galaxy modules, or EYAML again. Or if we do, we can just

```
rm -rf ansible/ansible-deps-cache
```

[What is ansible.suitcase?](https://github.com/epfl-si/ansible.suitcase)