### PR TITLE
[Feature] Propagate environment through ConfigMaps and Secrets

### DIFF
--- a/ansible/roles/awx-instance/tasks/container-group.yml
+++ b/ansible/roles/awx-instance/tasks/container-group.yml
@@ -68,6 +68,11 @@
             tty: true
             stdin: true
             imagePullPolicy: Always
+            envFrom:
+              - configMapRef:
+                  name: jahia2wp-env
+              - secretRef:
+                  name: mysql-super-credentials
             env:
               # Just to mute a stray error in /bin/entrypoint
               - name: CURRENT_UID

--- a/ansible/roles/wordpress-instance/vars/jahia2wp-vars.yml
+++ b/ansible/roles/wordpress-instance/vars/jahia2wp-vars.yml
@@ -26,4 +26,4 @@ jahia2wp_url: "{{ wp_base_url }}"
 # jahia2wp command. Use like so:
 #
 # shell: {{ jahia2wp_shell }} generate --foo=bar ...
-jahia2wp_shell: set -e; . {{ jahia2wp_dir }}/.env; export MYSQL_DB_HOST MYSQL_SUPER_USER MYSQL_SUPER_PASSWORD WP_ADMIN_USER WP_ADMIN_EMAIL; export WP_ENV='{{ wp_env }}'; export WP_VERSION=unused; cd {{ jahia2wp_dir }}/src; /srv/{{ wp_env }}/venv/bin/python ./jahia2wp.py
+jahia2wp_shell: set -e; cd {{ jahia2wp_dir }}/src; . /etc/profile.d/k8s-env.sh; env WP_ENV='{{ wp_env }}' /srv/{{ wp_env }}/venv/bin/python ./jahia2wp.py

--- a/ansible/roles/wordpress-openshift-namespace/tasks/mgmt.yml
+++ b/ansible/roles/wordpress-openshift-namespace/tasks/mgmt.yml
@@ -1,6 +1,7 @@
 - include_vars: mgmt-vars.yml
 - include_vars: ../../../vars/ssh-keys.yml  # Required by mgmt-vars.yml
 - include_vars: ../../../vars/image-vars.yml              # For mgmt_image_name
+- include_vars: "secrets-{{ openshift_namespace }}.yml"
 
 - name: "{{ mgmt_secret_name }} secret (ssh host and user keys)"
   openshift:
@@ -15,6 +16,33 @@
           app: mgmt
       data:
         {{ mgmt_secret_contents | to_yaml | indent(width=2) }}
+
+- name: jahia2wp-env ConfigMap
+  openshift:
+    state: latest
+    apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      name: jahia2wp-env
+      namespace: "{{ openshift_namespace }}"
+    data:
+      WP_ADMIN_USER: admin
+      WP_ADMIN_EMAIL: test@example.com
+      WP_VERSION: unused
+
+- name: mysql-super-credentials Secret
+  openshift:
+    state: latest
+    apiVersion: v1
+    kind: Secret
+    metadata:
+      name: mysql-super-credentials
+      namespace: "{{ openshift_namespace }}"
+    type: Opaque
+    data:
+      MYSQL_DB_HOST: "{{ mysql_super_credentials.host | b64encode }}"
+      MYSQL_SUPER_USER: "{{ mysql_super_credentials.user | b64encode }}"
+      MYSQL_SUPER_PASSWORD: "{{ mysql_super_credentials.password | eyaml(eyaml_keys) | b64encode }}"
 
 - name: mgmt DeploymentConfig
   openshift:
@@ -53,6 +81,11 @@
               - name: backups
                 mountPath: /backups
       {% endif %}
+              envFrom:
+                - configMapRef:
+                    name: jahia2wp-env
+                - secretRef:
+                    name: mysql-super-credentials
             serviceAccount: {{ mgmt_service_account }}
             serviceAccountName: {{ mgmt_service_account }}
             volumes:

--- a/ansible/roles/wordpress-openshift-namespace/vars/secrets-wwp-test.yml
+++ b/ansible/roles/wordpress-openshift-namespace/vars/secrets-wwp-test.yml
@@ -1,0 +1,18 @@
+# To edit the encrypted secrets below, you need eyaml installed.
+# Familiarize yourself with
+# https://puppet.com/blog/encrypt-your-data-using-hiera-eyaml first.
+# The edit command goes like this,
+#
+#   eyaml edit -d \
+#     --pkcs7-public-key ansible/eyaml/epfl_wp_test.pem \
+#     ansible/roles/wordpress-openshift-namespace/vars/secrets-wwp-test.yml
+#
+# 💡 This *will not* decrypt anything for you because chances are, you
+# don't need to decrypt secrets (YA RLY). For those cases where you
+# do, wielding the private key from Keybase is left as an exercise to
+# the reader.
+
+mysql_super_credentials:
+  host: db-wwp.epfl.ch
+  user: oswproot
+  password: ENC[PKCS7,MIIBiQYJKoZIhvcNAQcDoIIBejCCAXYCAQAxggEhMIIBHQIBADAFMAACAQEwDQYJKoZIhvcNAQEBBQAEggEATvqqylC7kf78EVi0unKPRcASCIOV+77qcdYXl9EEtJT9aNbodrYg+oM/0jJScQ3TlPmoqFCLJHUA7FOnmAmonIwqNJ5SUYAOFRN1eftuxLSeg0Tn2CqH/9x3dCig8AZ+4DP1/5KBIVljTpbMZd4MaQr7lKZulpzl5EdCHnSmrro6fqnwr8ebnxOxFCxH6vwDt68czvfuxonE+21sN5UwwMDQ590vp7PmyowWgBnVd5xAaP+uI26NtpxsSMYRXE+gp4blD4Ntd/nMtCwBvWXqv5UHTlux+8NxWeFgtFHj8Q61O6FOoTPb6072bV3Y091m4QKBzvf8ZzHSkg60KitV6zBMBgkqhkiG9w0BBwEwHQYJYIZIAWUDBAEqBBCk+PxidO78uJVrgfkZGj08gCB7RBfIbQby1sTGfPppxO2Fa0mB1w7549aOxYJaf2l4uw==]

--- a/ansible/roles/wordpress-openshift-namespace/vars/secrets-wwp.yml
+++ b/ansible/roles/wordpress-openshift-namespace/vars/secrets-wwp.yml
@@ -1,0 +1,18 @@
+# To edit the encrypted secrets below, you need eyaml installed.
+# Familiarize yourself with
+# https://puppet.com/blog/encrypt-your-data-using-hiera-eyaml first.
+# The edit command goes like this,
+#
+#   eyaml edit -d \
+#     --pkcs7-public-key ansible/eyaml/epfl_wp_prod.pem \
+#     ansible/roles/wordpress-openshift-namespace/vars/secrets-wwp.yml
+#
+# 💡 This *will not* decrypt anything for you because chances are, you
+# don't need to decrypt secrets (YA RLY). For those cases where you
+# do, wielding the private key from Keybase is left as an exercise to
+# the reader.
+
+mysql_super_credentials:
+  host: db-wwp.epfl.ch
+  user: oswproot
+  password: ENC[PKCS7,MIIBiQYJKoZIhvcNAQcDoIIBejCCAXYCAQAxggEhMIIBHQIBADAFMAACAQEwDQYJKoZIhvcNAQEBBQAEggEAhQrxreyVJ1+FfZXad6k7+B5nwHQmHufkGFwmjmRLRNOlPkFI3AUetZQlZLRdnxJLRCk9/MCDrvwxoM5WponQXWmia8cnDLJWaWCnWiWDR/nXT4Y/zGogS04/uTueCvXhlXDQiJ/BCAy9fRRamT2RHdeuGLoNYnjw/o1hoaJCERLPVTzk3CH3BLzBGiFRLO24PvjdGlN9HzuE+kAP4Rioe+S0RDFfE7vBw1FnzaUgqmlX4LWMw5aDuxp68zvFsof6Je3FIL91s0QLG+d6gFsQ0onQoq/O+N6CtG5x6cHcHvVK68zvkeZm5eBl+BQMwTsE9TkkB6G3eDqkotdgsK5tgDBMBgkqhkiG9w0BBwEwHQYJYIZIAWUDBAEqBBCIAB2AiqvOSdVDQe+c/pq+gCC5CztzXWK10DHVdaBGiI9cUa5we+HTDRrnQYU+wpClQg==]

--- a/docker/mgmt/docker-entrypoint.sh
+++ b/docker/mgmt/docker-entrypoint.sh
@@ -23,8 +23,19 @@ iwait() {
     esac
 }
 
+save_env_for_ssh_users() {
+    env -0 | while IFS== read -d '' var val; do
+        case "$var" in
+            WP_*|MYSQL_*|HTTPD_*|MGMT_*|KUBERNETES_*|JENKINS_*|POLYLEX_*|VARNISH_*|AWX_*)
+                printf "export %s=\"%q\"\n" "$var" "$val" ;;
+            *) : ;;
+        esac
+    done > /etc/profile.d/k8s-env.sh
+}
+
 ################################################
 
+save_env_for_ssh_users
 /usr/sbin/sshd -D &
 SSHD_PID=$!
 


### PR DESCRIPTION
We can now stop keeping the master secret of the EPFL WordPress platform on NFS.

- Keep `WP_ENV` as a “free-floating” variable, that must be passed around whenever jahia2wp gets invoked
- Put the other `WP_*` variables into a ConfigMap and the MYSQL_* variables into a Secret
- Generate `/etc/profile.d/k8s-env.sh` from within `docker-entrypoint.sh` so that ssh users also obtain these variables in their environment
