### PR TITLE
[refactor] The return of `tags: always`

### DIFF
--- a/ansible/playbooks/filter_plugins/tags.py
+++ b/ansible/playbooks/filter_plugins/tags.py
@@ -1,0 +1,63 @@
+"""'Short-circuit roles with tags' feature.
+
+When `ansible_run_tags | any_known_tag(role_path)` is
+False, we can (and should) skip the entire role. This lets role
+authors employ `tags: always` when they don't really mean it.
+"""
+
+import yaml
+import os
+from ansible.module_utils import six
+
+class FilterModule(object):
+    def filters(self):
+        return {
+            'any_known_tag': self.any_known_tag
+        }
+
+    def any_known_tag(self, tags, role_path):
+        tags = set(tags)
+        if 'all' in tags:  # i.e., no tags
+            return True
+        return bool(tags.intersection(
+            _TagShaker.of(os.path.join(role_path, 'tasks')).get_role_tags_set()))
+
+class _TagShaker(object):
+    _instances = {}
+    @classmethod
+    def of(cls, templates_path):
+        if templates_path not in cls._instances:
+            cls._instances[templates_path] = cls(templates_path)
+        return cls._instances[templates_path]
+
+    def __init__(self, templates_path):
+        self._tasks_path = templates_path
+
+    def get_role_tags_set(self):
+        if not hasattr(self, '_role_tags_cached'):
+            self._role_tags_cached = set(self._walk_all_role_tags())
+        return self._role_tags_cached
+
+    def _walk_all_role_tags(self):
+        for parentdir, subdirs, files in os.walk(self._tasks_path):
+            for filename in files:
+                if filename.startswith('.') or filename.endswith('~'):
+                    continue
+                try:
+                    parsed = yaml.safe_load(open(os.path.join(parentdir, filename)))
+                except Exception:
+                    continue
+                if type(parsed) is not list:
+                    continue
+                for task in parsed:
+                    if type(task) is not dict:
+                        continue
+                    if 'tags' not in task:
+                        continue
+                    tags = task['tags']
+                    if isinstance(tags, six.string_types):
+                        tags = [tags]
+                    if type(tags) is list:
+                        for tag in tags:
+                            if tag not in ('always', 'never'):
+                                yield tag

--- a/ansible/roles/wordpress-instance/tasks/backup.yml
+++ b/ansible/roles/wordpress-instance/tasks/backup.yml
@@ -4,11 +4,11 @@
   command: mktemp -d -p {{ wp_dir }} -t ansible-backup-XXXXXX
   changed_when: false
   register: _backup_tmpdir_cmd
-  tags: "{{ all_wordpress_instance_tags }}"
+  tags: always
 
 - set_fact:
     _backup_tmpdir: "{{ _backup_tmpdir_cmd.stdout }}"
-  tags: "{{ all_wordpress_instance_tags }}"
+  tags: always
 
 - name: Back up code to {{ _backup_tmpdir }} — 💡 In case of a catastrophe, you will find your files there.
   shell: |

--- a/ansible/roles/wordpress-instance/tasks/main.yml
+++ b/ansible/roles/wordpress-instance/tasks/main.yml
@@ -5,8 +5,12 @@
 # Variables:: (in addition to those defined or documented in
 #              ../vars/*.yml)
 
+- meta: end_play
+  when: |
+    not ( ansible_run_tags | any_known_tag(role_path) )
+
 - include_vars: wp-destructive.yml   # For wp_can
-  tags: "{{ all_wordpress_instance_tags }}"
+  tags: always
 
 - name: Backup
   # We include_tasks (not import_tasks) here, because we do *not* want
@@ -30,7 +34,7 @@
     - wipe
 
 - wordpress_facts:
-  tags: "{{ all_wordpress_instance_tags }}"
+  tags: always
 
 - name: "{{ 'Recreate' if 'wipe' in ansible_run_tags else 'Create' }}"
   include_tasks: "create.yml"

--- a/ansible/roles/wordpress-instance/tasks/symlink.yml
+++ b/ansible/roles/wordpress-instance/tasks/symlink.yml
@@ -20,10 +20,10 @@
       - (wp_can.configure and wp_can.write_code) or ansible_check_mode
 
 - include_vars: symlink-vars.yml
-  tags: "{{ all_wordpress_instance_tags }}"
+  tags: always
 
 - name: "Set wp_is_symlinked"
-  tags: "{{ all_wordpress_instance_tags }}"
+  tags: always
   set_fact:
     wp_is_symlinked: '{{ "symlink" in ansible_run_tags }}'
 

--- a/ansible/roles/wordpress-instance/vars/main.yml
+++ b/ansible/roles/wordpress-instance/vars/main.yml
@@ -46,17 +46,3 @@ wpveritas_api_url: '{{ _wpveritas_servers[openshift_namespace] }}'
 _wpveritas_servers:
   wwp: https://wp-veritas.epfl.ch/api
   wwp-test: https://wp-veritas.128.178.222.83.nip.io/api
-
-all_wordpress_instance_tags:
-    - wipe
-    - backup
-    - backup.code
-    - backup.data
-    - backup.uploads
-    - restore
-    - symlink
-    - unsymlink
-    - config
-    - plugins
-    - themes
-    - convert-shortcode-to-block


### PR DESCRIPTION
Enumerate the tags by walking all YAML task files in a filter_plugin instead.
