### PR TITLE
[feature] Remove unknown installed plug-ins

### DIFF
--- a/ansible/inventory/wordpress-instances.py
+++ b/ansible/inventory/wordpress-instances.py
@@ -214,8 +214,8 @@ class _LiveSite(_Site):
 
 
 class LiveTestSite(TestSiteTrait, _LiveSite):
-    _find_in_dirs = '/srv'
-    _excluded_paths = ['/srv/lvenries', '/srv/jenkins', '/srv/int/jahia2wp/data/backups']
+    _find_in_dirs = '/srv/dev /srv/int'
+    _excluded_paths = ['/srv/int/jahia2wp/data/backups']
 
 
 class LiveProductionSite(ProdSiteTrait, _LiveSite):

--- a/ansible/roles/wordpress-instance/action_plugins/wordpress_action_module.py
+++ b/ansible/roles/wordpress-instance/action_plugins/wordpress_action_module.py
@@ -137,12 +137,9 @@ class WordPressActionModule(ActionBase):
                 # Simulate "orange" condition
                 result = dict(changed=True)
 
-        # https://www.ansible.com/blog/how-to-extend-ansible-through-plugins at "Action Plugins"
         if result is None:
             try:
-                result = self._execute_module(module_name=action_name,
-                                              module_args=args, tmp=self._tmp,
-                                              task_vars=self._task_vars)
+                result = self._do_run_action(action_name, args)
             finally:
                 self._play_context.check_mode = check_mode_orig
 
@@ -152,6 +149,13 @@ class WordPressActionModule(ActionBase):
 
         else:
             return result
+
+
+    def _do_run_action(self, action_name, args):
+        # https://www.ansible.com/blog/how-to-extend-ansible-through-plugins at "Action Plugins"
+        return self._execute_module(module_name=action_name,
+                                    module_args=args, tmp=self._tmp,
+                                    task_vars=self._task_vars)
 
 
     def _get_wp_dir (self):

--- a/ansible/roles/wordpress-instance/action_plugins/wordpress_action_module.py
+++ b/ansible/roles/wordpress-instance/action_plugins/wordpress_action_module.py
@@ -203,15 +203,15 @@ class WordPressActionModule(ActionBase):
         oldresult = deepcopy(self.result)
         self.result.update(result)
 
-        def _keep_flag(flag_name):
+        def _keep_flag_truthy(flag_name):
             if (flag_name in oldresult and
                 oldresult[flag_name] and
                 flag_name in self.result and
-                not result[flag_name]
+                not self.result[flag_name]
             ):
                 self.result[flag_name] = oldresult[flag_name]
 
-        _keep_flag('changed')
+        _keep_flag_truthy('changed')
 
         return self.result
 

--- a/ansible/roles/wordpress-instance/action_plugins/wordpress_plugin.py
+++ b/ansible/roles/wordpress-instance/action_plugins/wordpress_plugin.py
@@ -10,7 +10,6 @@ import json
 # To be able to import wordpress_action_module
 sys.path.append(os.path.dirname(__file__))
 
-from ansible.errors import AnsibleActionFail
 from ansible.module_utils import six
 from wordpress_action_module import WordPressPluginOrThemeActionModule
 

--- a/ansible/roles/wordpress-instance/action_plugins/wordpress_unknown_plugins.py
+++ b/ansible/roles/wordpress-instance/action_plugins/wordpress_unknown_plugins.py
@@ -12,6 +12,7 @@ from ansible.plugins.action import ActionBase
 sys.path.append(os.path.dirname(__file__))
 from wordpress_action_module import WordPressActionModule
 from wordpress_plugin import ActionModule as WordPressPluginActionModule
+from ansible.errors import AnsibleError
 
 class ActionModule(WordPressActionModule):
     def run(self, tmp=None, task_vars=None):
@@ -48,6 +49,8 @@ class ActionModule(WordPressActionModule):
     def known_plugins(self):
         if not hasattr(self, '_known_plugins'):
             self._known_plugins = set(self._scrape_known_plugins(self._task.args['known_plugins_in']))
+            if not self._known_plugins:
+                raise AnsibleError("No known plugins?! Refusing to proceed.")
         return self._known_plugins
 
 

--- a/ansible/roles/wordpress-instance/action_plugins/wordpress_unknown_plugins.py
+++ b/ansible/roles/wordpress-instance/action_plugins/wordpress_unknown_plugins.py
@@ -1,0 +1,57 @@
+"""What to do with unknown WordPress plug-ins.
+
+Right now the only supported action is to delete them (with "state: absent").
+"""
+
+import sys
+import os.path
+import yaml
+
+from ansible.plugins.action import ActionBase
+
+sys.path.append(os.path.dirname(__file__))
+from wordpress_action_module import WordPressActionModule
+from wordpress_plugin import ActionModule as WordPressPluginActionModule
+
+class ActionModule(WordPressActionModule):
+    def run(self, tmp=None, task_vars=None):
+        self.result = super(ActionModule, self).run(tmp, task_vars)
+
+        state = self._task.args.get('state')
+        if not state:
+            return
+        elif state != 'absent':
+            raise AnsibleActionFail("Unknown state '%s' for wordpress_unknown_plugins" % state)
+
+        if 'wordpress_unknown_plugins' not in self.result:
+            self.result['wordpress_unknown_plugins'] = []
+        for name in self.get_installed_or_symlinked_plugins(task_vars):
+            if name not in self.known_plugins:
+                self._run_action('wordpress_plugin', dict(name=name, state=state))
+                self.result['wordpress_unknown_plugins'].append(name)
+
+        return self.result
+
+    def get_installed_or_symlinked_plugins(self, task_vars):
+        unexpanded = task_vars.get('wp_plugin_list', None)
+        if unexpanded is None:
+            return set()
+
+        wp_plugin_list = self._templar.template(unexpanded)
+        return set(p['name'] for p in wp_plugin_list if p['status'] != 'must-use')
+
+    @property
+    def known_plugins(self):
+        if not hasattr(self, '_known_plugins'):
+            self._known_plugins = set(self._scrape_known_plugins(self._task.args['known_plugins_in']))
+        return self._known_plugins
+
+
+    def _scrape_known_plugins(self, path):
+        parsed = yaml.safe_load(open(path))
+        for task in parsed:
+            task_args = task.get('wordpress_plugin')
+            if type(task_args) is not dict:
+                continue
+            if 'name' in task_args:
+                yield task_args['name']

--- a/ansible/roles/wordpress-instance/tasks/main.yml
+++ b/ansible/roles/wordpress-instance/tasks/main.yml
@@ -85,6 +85,7 @@
   tags:
     - plugins
     - plugins.wp_media_folder_options
+    - plugins.unknown
   include_tasks:
     file: "plugins.yml"
     apply:

--- a/ansible/roles/wordpress-instance/tasks/plugins.yml
+++ b/ansible/roles/wordpress-instance/tasks/plugins.yml
@@ -513,3 +513,9 @@
     name: mainwp
     state: "{{ plugins_for_admin_category }}"
     from: wordpress.org/plugins
+
+- name: Uninstall all unknown plug-ins
+  tags: plugins.unknown
+  wordpress_unknown_plugins:
+    state: absent
+    known_plugins_in: "{{ role_path }}/tasks/plugins.yml"  # i.e. this here file

--- a/ansible/roles/wordpress-instance/tasks/plugins.yml
+++ b/ansible/roles/wordpress-instance/tasks/plugins.yml
@@ -31,7 +31,7 @@
 
 - name: Custom editor menu (must-use plugin)
   wordpress_plugin:
-    name: EPFL_custom_editor_menu
+    name: EPFL_custom_editor_menu_loader
     is_mu: yes
     state: '{{ "symlinked" if wp_is_managed else "absent" }}'
     from:


### PR DESCRIPTION
- New `wordpress_unknown_plugins` action module, which only does
anything with `state: absent`
- Collect the removed WordPress plug-ins into the
`wordpress_unknown_plugins` field of the `result` (visible under
`ansible-playbook -v`)
- Supports `--check`