### PR TITLE
[feature] `wpsible -t menus.wp.refresh`

### DIFF
--- a/ansible/roles/wordpress-instance/tasks/main.yml
+++ b/ansible/roles/wordpress-instance/tasks/main.yml
@@ -108,7 +108,7 @@
   tags:
     - convert-shortcode-to-block
 
-- name: Sync menus
+- name: Set up menus
   include_tasks:
     file: "menus.yml"
     apply:

--- a/ansible/roles/wordpress-instance/tasks/main.yml
+++ b/ansible/roles/wordpress-instance/tasks/main.yml
@@ -108,3 +108,12 @@
   tags:
     - convert-shortcode-to-block
 
+- name: Sync menus
+  include_tasks:
+    file: "menus.yml"
+    apply:
+      tags: ["wp.menus"]
+  tags:
+    - never
+    - wp.menus
+    - wp.menus.refresh

--- a/ansible/roles/wordpress-instance/tasks/menus.yml
+++ b/ansible/roles/wordpress-instance/tasks/menus.yml
@@ -1,0 +1,5 @@
+- name: Sync menus
+  shell:
+    cmd: "{{ wp_cli_command }} epfl menus refresh"
+  tags:
+    - wp.menus.refresh


### PR DESCRIPTION
As per today's work, Ansiblify the command to refresh menus (even though it would be unwise to use it yet!)

- New tasks file `menu.yml`
- Guarded by `tags: never`, so it won't fire unless we explicitly pass `-t menus.wp.refresh` (tested with `./ansible/wpsible --prod -l www__campus__services__canari`)
