### PR TITLE
[to merge on Wednesday, 13 May] New plugin names

### DIFF
--- a/ansible/roles/wordpress-instance/tasks/plugins.yml
+++ b/ansible/roles/wordpress-instance/tasks/plugins.yml
@@ -202,7 +202,7 @@
     state:
       - symlinked
       - active
-    from: https://github.com/epfl-si/jahia2wp/tree/rename-copied-plugins/data/wp/wp-content/plugins/epfl-cache-control
+    from: https://github.com/epfl-si/jahia2wp/tree/release2018/data/wp/wp-content/plugins/epfl-cache-control
 
 - name: Cache-Control options
   wordpress_option: "{{ item }}"
@@ -246,7 +246,7 @@
     state:
       - symlinked
       - active
-    from: https://github.com/epfl-si/jahia2wp/tree/rename-copied-plugins/data/wp/wp-content/plugins/epfl-remote-content-shortcode
+    from: https://github.com/epfl-si/jahia2wp/tree/release2018/data/wp/wp-content/plugins/epfl-remote-content-shortcode
 
 - name: shortcode-ui plugin
   wordpress_plugin:

--- a/ansible/roles/wordpress-instance/tasks/plugins.yml
+++ b/ansible/roles/wordpress-instance/tasks/plugins.yml
@@ -198,11 +198,11 @@
 
 - name: Cache-Control plugin
   wordpress_plugin:
-    name: cache-control
+    name: epfl-cache-control
     state:
       - symlinked
       - active
-    from: https://github.com/epfl-si/jahia2wp/tree/release2018/data/wp/wp-content/plugins/cache-control
+    from: https://github.com/epfl-si/jahia2wp/tree/rename-copied-plugins/data/wp/wp-content/plugins/epfl-cache-control
 
 - name: Cache-Control options
   wordpress_option: "{{ item }}"
@@ -242,11 +242,11 @@
 
 - name: remote-content-shortcode plugin
   wordpress_plugin:
-    name: remote-content-shortcode
+    name: epfl-remote-content-shortcode
     state:
       - symlinked
       - active
-    from: https://github.com/epfl-si/jahia2wp/tree/release2018/data/wp/wp-content/plugins/remote-content-shortcode
+    from: https://github.com/epfl-si/jahia2wp/tree/rename-copied-plugins/data/wp/wp-content/plugins/epfl-remote-content-shortcode
 
 - name: shortcode-ui plugin
   wordpress_plugin:


### PR DESCRIPTION
Adaptation suite à la PR https://github.com/epfl-si/jahia2wp/pull/1169 qui renomme des plugins. On prend les nouveaux noms pour la génération de l'image.