### PR TITLE
Fix error nothing provides epel-release = 7 needed by remi-release-7.…

### DIFF
--- a/ansible/roles/awx-instance/tasks/k8s-builds.yml
+++ b/ansible/roles/awx-instance/tasks/k8s-builds.yml
@@ -19,7 +19,7 @@
     dockerfile: |
       FROM docker-registry.default.svc:5000/{{ ansible_oc_namespace }}/{{ wp_base_image_name }}:latest
       FROM docker-registry.default.svc:5000/{{ ansible_oc_namespace }}/{{ awx_runner_base_image_name }}:latest
-
+      RUN yum -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
       RUN yum -y install http://rpms.remirepo.net/enterprise/remi-release-7.rpm
       RUN yum-config-manager --disable remi-php54 && \
           yum-config-manager --enable remi-php73


### PR DESCRIPTION
Depuis quelques jours, on a l'erreur suivante lors du build via jenkins :

```
Pulling image docker-registry.default.svc:5000/wwp-test/wp-base:latest ...
--> FROM docker-registry.default.svc:5000/wwp-test/wp-base:latest as 0
--> FROM docker-registry.default.svc:5000/wwp-test/ansible-runner:latest as 1
--> RUN yum -y install http://rpms.remirepo.net/enterprise/remi-release-7.rpm
CentOS-8 - AppStream                             23 MB/s | 7.0 MB     00:00    
CentOS-8 - Base                                 4.2 MB/s | 2.2 MB     00:00    
CentOS-8 - Extras                                14 kB/s | 6.7 kB     00:00    
Ansible Runner for EL 8 - x86_64                 16 kB/s | 7.7 kB     00:00    
Extra Packages for Enterprise Linux Modular 8 - 210 kB/s | 118 kB     00:00    
Extra Packages for Enterprise Linux 8 - x86_64  7.1 MB/s | 6.8 MB     00:00    
remi-release-7.rpm                               80 kB/s |  20 kB     00:00    
Error: 
 Problem: conflicting requests
  - nothing provides epel-release = 7 needed by remi-release-7.7-2.el7.remi.noarch
(try to add '--skip-broken' to skip uninstallable packages or '--nobest' to use not only best candidate packages)
error: build error: running 'yum -y install http://rpms.remirepo.net/enterprise/remi-release-7.rpm' failed with exit code 1
```

Comme expliqué [ici](https://superuser.com/questions/1150305/remi-repository-on-centos-7-fails-dependency) : on doit simplement installer [EPEL](https://fedoraproject.org/wiki/EPEL) repository