### PR TITLE
[feature] More k8s in Ansible

### DIFF
--- a/ansible/inventory/test/group_vars/openshift_namespaces_dev
+++ b/ansible/inventory/test/group_vars/openshift_namespaces_dev
@@ -8,14 +8,17 @@ ansible_connection: local  # Unless stipulated otherwise in a task
 openshift_namespace: wwp-test
 
 DeploymentConfigs:
+  defaults:
+    replicaCount:
+      httpd: 1
   httpd:
-    - name: httpd-cburki
-    - name: httpd-dev
-    - name: httpd-gcharmier
-    - name: httpd-int
+    - name: cburki
+    - name: dev
+    - name: gcharmier
+    - name: int
       autopush: true
-    - name: httpd-lchaboudez
-    - name: httpd-lvenries
+    - name: lchaboudez
+    - name: lvenries
 
 eyaml_keys:
   priv: "/keybase/team/epfl_wp_test/eyaml-privkey.pem"

--- a/ansible/roles/awx-instance/tasks/k8s.yml
+++ b/ansible/roles/awx-instance/tasks/k8s.yml
@@ -192,20 +192,20 @@
           - name: awx-application-config
             configMap:
               name: awx-config
-              defaultMode: 420
+              defaultMode: 0644
               items:
               - key: awx_settings
                 path: settings.py
           - name: awx-redis-config
             configMap:
               name: awx-config
-              defaultMode: 420
+              defaultMode: 0644
               items:
               - key: redis_conf
                 path: redis.conf
           - name: awx-application-credentials
             secret:
-              defaultMode: 420
+              defaultMode: 0644
               items:
               - key: credentials_py
                 path: credentials.py

--- a/ansible/roles/wordpress-openshift-namespace/tasks/deploymentconfig-httpd.yml
+++ b/ansible/roles/wordpress-openshift-namespace/tasks/deploymentconfig-httpd.yml
@@ -1,27 +1,125 @@
-# Set up (a cautious subset of) one DeploymentConfig/httpd-* object,
-# described by the {{ dc }} variable.
+# Set up one DeploymentConfig/httpd-* object, described by the
+# {{ dc }} variable.
 
 - include_vars: ../../../vars/image-vars.yml              # For httpd_image_name
 
-- name: "dc/{{ dc.name }}"
+- name: "dc/httpd-{{ dc.name }}"
   openshift:
-   state: latest
-   content: |
-     apiVersion: apps.openshift.io/v1
-     kind: DeploymentConfig
-     metadata:
-       name: "{{ dc.name }}"
-       namespace: "{{ openshift_namespace }}"
-       labels:
-         serving_role: httpd
-     spec:
-       triggers:
-       - type: ImageChange
-         imageChangeParams:
-           {{ 'automatic: true' if (dc.autopush | default(None)) else '' }}
+    state: latest
+    apiVersion: apps.openshift.io/v1
+    kind: DeploymentConfig
+    metadata:
+      name: "httpd-{{ dc.name }}"
+      namespace: "{{ openshift_namespace }}"
+      labels:
+        app: "httpd-{{ dc.name }}"
+        serving_role: httpd
+    spec:
+      replicas: "{{ dc.replicaCount | default(DeploymentConfigs.defaults.replicaCount.httpd) }}"
+      selector:
+        app: "httpd-{{ dc.name }}"
+        deploymentconfig: "httpd-{{ dc.name }}"
+      template:
+        metadata:
+          labels:
+            app: "httpd-{{ dc.name }}"
+            deploymentconfig: "httpd-{{ dc.name }}"
+        spec:
+          affinity:
+            podAntiAffinity:
+              # This pod doesn't like running on a VM that has another
+              # copy of itself (obviously for HA purposes)
+              requiredDuringSchedulingIgnoredDuringExecution:
+              - labelSelector:
+                  matchExpressions:
+                  - key: deploymentconfig
+                    operator: In
+                    values:
+                    - "httpd-{{ dc.name }}"
+                topologyKey: kubernetes.io/hostname
+
+          containers:
+          - env:
+            - name: WP_ENV
+              value: "{{ dc.name }}"
+            # image will be set from the imageStream
+            imagePullPolicy: Always
+            name: "httpd-{{ dc.name }}"
+            ports:
+            - containerPort: 8080
+              protocol: TCP
+            - containerPort: 8443
+              protocol: TCP
+            - containerPort: 9980
+              protocol: TCP
+            readinessProbe:
+              failureThreshold: 3
+              httpGet:
+                path: /ready
+                port: 8080
+                scheme: HTTP
+              initialDelaySeconds: 5
+              periodSeconds: 15
+              successThreshold: 1
+              timeoutSeconds: 1
+            resources: {}
+            terminationMessagePath: /dev/termination-log
+            terminationMessagePolicy: File
+            volumeMounts:
+            - mountPath: "/srv/{{ dc.name }}"
+              name: "volume-wordpress-{{ dc.name }}"
+            - mountPath: /webservices/logs
+              name: "webservices-logs-{{ dc.name }}"
+            - mountPath: /call_logs
+              name: "call-logs-{{ dc.name }}"
+          - image: docker-registry.default.svc:5000/wwp-test/collectd:latest
+            imagePullPolicy: Always
+            name: "collectd-{{ dc.name }}"
+            ports:
+            - containerPort: 9103
+              protocol: TCP
+            resources: {}
+            terminationMessagePath: /dev/termination-log
+            terminationMessagePolicy: File
+          - env:
+            - name: WP_ENV
+              value: "{{ dc.name }}"
+            - name: LINE
+              value: test
+            image: docker-registry.default.svc:5000/wwp-test/filebeat-call-logs:latest
+            imagePullPolicy: Always
+            name: "filebeat-{{ dc.name }}"
+            resources: {}
+            terminationMessagePath: /dev/termination-log
+            terminationMessagePolicy: File
+            volumeMounts:
+            - mountPath: /webservices/logs
+              name: "webservices-logs-{{ dc.name }}"
+            - mountPath: /call_logs
+              name: "call-logs-{{ dc.name }}"
+          dnsPolicy: ClusterFirst
+          restartPolicy: Always
+          schedulerName: default-scheduler
+          securityContext: {}
+          serviceAccount: wwp-test
+          serviceAccountName: wwp-test
+          terminationGracePeriodSeconds: 30
+          volumes:
+          - name: "volume-wordpress-{{ dc.name }}"
+            persistentVolumeClaim:
+              claimName: "wordpress-{{ dc.name }}"
+          - emptyDir: {}
+            name: "webservices-logs-{{ dc.name }}"
+          - emptyDir: {}
+            name: "call-logs-{{ dc.name }}"
+
+      triggers:
+      - type: ImageChange
+        imageChangeParams:
+           automatic: "{{ true if (dc.autopush | default(None)) else None }}"
            containerNames:
-           - "{{ dc.name }}"
+           - "httpd-{{ dc.name }}"
            from:
              kind: ImageStreamTag
-             name: {{ httpd_image_name }}:{{ openshift_registry_tag }}
-             namespace: "{{ openshift_namespace }}"
+             name: "{{ httpd_image_name }}:{{ openshift_registry_tag }}"
+             namespace: "{{ wwp_build_namespace }}"

--- a/ansible/roles/wordpress-openshift-namespace/tasks/disk-usage-report.yml
+++ b/ansible/roles/wordpress-openshift-namespace/tasks/disk-usage-report.yml
@@ -3,98 +3,89 @@
 - name: BuildConfig for the customized Perl Docker image
   openshift:
     state: latest
-    content: |
-      apiVersion: build.openshift.io/v1
-      kind: BuildConfig
-      metadata:
-        name: perl-disk-usage-report
-        namespace: "{{ openshift_namespace }}"
-      spec:
-        output:
-          to:
-            kind: "DockerImage"
-            name: "docker-registry.default.svc:5000/{{ openshift_namespace }}/perl-disk-usage-report:latest"
-        source:
-          type: Dockerfile
-          dockerfile: |
-            FROM perl
-            RUN cpan URI::Escape
-        runPolicy: Serial
-        strategy:
-          dockerStrategy:
-            noCache: true
-          type: Docker
-        successfulBuildsHistoryLimit: 5
+    apiVersion: build.openshift.io/v1
+    kind: BuildConfig
+    metadata:
+      name: perl-disk-usage-report
+      namespace: "{{ openshift_namespace }}"
+    spec:
+      output:
+        to:
+          kind: "DockerImage"
+          name: "docker-registry.default.svc:5000/{{ openshift_namespace }}/perl-disk-usage-report:latest"
+      source:
+        type: Dockerfile
+        dockerfile: |
+          FROM perl
+          RUN cpan URI::Escape
+      runPolicy: Serial
+      strategy:
+        dockerStrategy:
+          noCache: true
+        type: Docker
+      successfulBuildsHistoryLimit: 5
 
 - name: Perl script as a ConfigMap
   openshift:
     state: latest
-    content: |
-      apiVersion: v1
-      kind: ConfigMap
-      metadata:
-        name: srv-disk-usage-report-scripts
-        namespace: "{{ openshift_namespace }}"
-      data:
-        qdirstat-cache-writer: |
-          {# A Jinja "include" doesn't work here, because the include
-           # directory is random and Jinja forbids leaving it with ../
-           # or / (think path traversal attacks). The Ansible "lookup"
-           # function comes to the rescue: -#}
-          {{ lookup("file", "templates/qdirstat-cache-writer") | indent(width=4) }}
-          {# Indent width is relative to the outermost ": |" construct,
-           # i.e. the "a" of "apiVersion" (on the other hand,
-           # too much indent would hardly matter in a Perl script) #}
+    apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      name: srv-disk-usage-report-scripts
+      namespace: "{{ openshift_namespace }}"
+    data:
+      # A Jinja "include" doesn't work here, because the include
+      # directory is random and Jinja forbids leaving it with ../
+      # or / (think path traversal attacks). The Ansible "lookup"
+      # function comes to the rescue:
+      qdirstat-cache-writer: '{{ lookup("file", "templates/qdirstat-cache-writer") }}'
 
 - name: Cron job
   openshift:
     state: latest
-    content: |
-      apiVersion: batch/v1beta1
-      kind: CronJob
-      metadata:
-        name: srv-disk-usage-report
-        namespace: "{{ openshift_namespace }}"
-      spec:
-        # If you want state: latest (above) to do what you want, you
-        # need to explicitly set everything (even if the value is the
-        # same as the default)
-        concurrencyPolicy: Forbid
-        schedule: "5 03 * * *"
-        jobTemplate:
-          spec:
-            template:
-              spec:
-                restartPolicy: Never
-                containers:
-                  - name: qdirstat-cache-writer
-                    image: docker-registry.default.svc:5000/{{ openshift_namespace }}/perl-disk-usage-report:latest
-                    imagePullPolicy: Always
-                    command:
-                      - /bin/sh
-                      - -c
-                      - |
-                        OUTDIR=/srv/batch/disk-usage-report
-                        TARGET=/srv
-                        exec >> $OUTDIR/log.txt 2>&1; set -e -x; date; id
-                        /scripts/qdirstat-cache-writer $TARGET $OUTDIR/qdirstat.NEW
-                        gzip -c $OUTDIR/qdirstat.NEW > $OUTDIR/qdirstat.gz
-                        rm $OUTDIR/qdirstat.NEW
-                    volumeMounts:
-                      - name: scripts
-                        mountPath: /scripts
-                      - name: srv
-                        mountPath: /srv
-                volumes:
-                - name: scripts
-                  configMap:
-                    name: srv-disk-usage-report-scripts
-                    items:
-                      - key: qdirstat-cache-writer
-                        path: qdirstat-cache-writer
-                        {# "Owing to JSON limitations, you must specify the
-                         # mode in decimal notation." -#}
-                        mode: {{ "0755" | int }}
-                - name: srv
-                  persistentVolumeClaim:
-                    claimName: wordpress-0
+    apiVersion: batch/v1beta1
+    kind: CronJob
+    metadata:
+      name: srv-disk-usage-report
+      namespace: "{{ openshift_namespace }}"
+    spec:
+      # If you want state: latest (above) to do what you want, you
+      # need to explicitly set everything (even if the value is the
+      # same as the default)
+      concurrencyPolicy: Forbid
+      schedule: "5 03 * * *"
+      jobTemplate:
+        spec:
+          template:
+            spec:
+              restartPolicy: Never
+              containers:
+                - name: qdirstat-cache-writer
+                  image: "docker-registry.default.svc:5000/{{ openshift_namespace }}/perl-disk-usage-report:latest"
+                  imagePullPolicy: Always
+                  command:
+                    - /bin/sh
+                    - -c
+                    - |
+                      OUTDIR=/srv/batch/disk-usage-report
+                      TARGET=/srv
+                      exec >> $OUTDIR/log.txt 2>&1; set -e -x; date; id
+                      /scripts/qdirstat-cache-writer $TARGET $OUTDIR/qdirstat.NEW
+                      gzip -c $OUTDIR/qdirstat.NEW > $OUTDIR/qdirstat.gz
+                      rm $OUTDIR/qdirstat.NEW
+                  volumeMounts:
+                    - name: scripts
+                      mountPath: /scripts
+                    - name: srv
+                      mountPath: /srv
+              volumes:
+              - name: scripts
+                configMap:
+                  name: srv-disk-usage-report-scripts
+                  items:
+                    - key: qdirstat-cache-writer
+                      path: qdirstat-cache-writer
+                      mode: 0755
+              - name: srv
+                persistentVolumeClaim:
+                  claimName: wordpress-0

--- a/ansible/roles/wordpress-openshift-namespace/tasks/mgmt.yml
+++ b/ansible/roles/wordpress-openshift-namespace/tasks/mgmt.yml
@@ -7,16 +7,14 @@
 - name: "{{ mgmt_secret_name }} secret (ssh host and user keys)"
   openshift:
     state: latest
-    content: |
-      apiVersion: v1
-      kind: Secret
-      metadata:
-        name: "{{ mgmt_secret_name }}"
-        namespace: "{{ openshift_namespace }}"
-        labels:
-          app: mgmt
-      data:
-        {{ mgmt_secret_contents | to_yaml | indent(width=2) }}
+    apiVersion: v1
+    kind: Secret
+    metadata:
+      name: "{{ mgmt_secret_name }}"
+      namespace: "{{ openshift_namespace }}"
+      labels:
+        app: mgmt
+    data: "{{ mgmt_secret_contents }}"
 
 - name: jahia2wp-env ConfigMap
   openshift:
@@ -48,67 +46,65 @@
 - name: mgmt DeploymentConfig
   openshift:
     state: latest
-    content: |
-      apiVersion: v1
-      kind: DeploymentConfig
-      metadata:
-        name: mgmt
-        namespace: "{{ openshift_namespace }}"
-        labels:
-          app: mgmt
-      spec:
-        replicas: 1
-        selector:
-          app: mgmt
-          deploymentconfig: mgmt
-        template:
-          metadata:
-            labels:
-              app: mgmt
-              deploymentconfig: mgmt
-          spec:
-            containers:
-            - name: mgmt
-              imagePullPolicy: Always
-              ports:
-              - containerPort: 22
-                protocol: TCP
-              volumeMounts:
-              - name: srv
-                mountPath: /srv
-              - name: ssh
-                mountPath: /var/lib/secrets/ssh
-      {% if openshift_is_production %}
-              - name: backups
-                mountPath: /backups
-      {% endif %}
-              envFrom:
-                - configMapRef:
-                    name: jahia2wp-env
-                - secretRef:
-                    name: mysql-super-credentials
-            serviceAccount: {{ mgmt_service_account }}
-            serviceAccountName: {{ mgmt_service_account }}
-            volumes:
+    apiVersion: v1
+    kind: DeploymentConfig
+    metadata:
+      name: mgmt
+      namespace: "{{ openshift_namespace }}"
+      labels:
+        app: mgmt
+    spec:
+      replicas: 1
+      selector:
+        app: mgmt
+        deploymentconfig: mgmt
+      template:
+        metadata:
+          labels:
+            app: mgmt
+            deploymentconfig: mgmt
+        spec:
+          containers:
+          - name: mgmt
+            imagePullPolicy: Always
+            ports:
+            - containerPort: 22
+              protocol: TCP
+            volumeMounts:
             - name: srv
-              persistentVolumeClaim:
-                claimName: wordpress-0
+              mountPath: /srv
             - name: ssh
-              secret:
-                secretName: "{{ mgmt_secret_name }}"
-      {% if openshift_is_production %}
+              mountPath: /var/lib/secrets/ssh
             - name: backups
-              persistentVolumeClaim:
-                claimName: backups-0
-      {% endif %}
-        triggers:
-        - type: ConfigChange
-        - type: ImageChange
-          imageChangeParams:
-            automatic: true
-            containerNames:
-            - mgmt
-            from:
-              kind: ImageStreamTag
-              name: "{{ mgmt_image_name }}:{{ openshift_registry_tag }}"
-              namespace: "{{ openshift_namespace }}"
+              mountPath: /backups
+            envFrom:
+              - configMapRef:
+                  name: jahia2wp-env
+              - secretRef:
+                  name: mysql-super-credentials
+          serviceAccount: "{{ mgmt_service_account }}"
+          serviceAccountName: "{{ mgmt_service_account }}"
+          volumes:
+          - name: srv
+            persistentVolumeClaim:
+              claimName: wordpress-0
+          - name: ssh
+            secret:
+              secretName: "{{ mgmt_secret_name }}"
+          - >-
+            {{ { "name": "backups",
+                 "persistentVolumeClaim": {"claimName": "backups-0"} }
+               if openshift_is_production
+               else { "name": "backups", "emptydir": {} }
+            }}
+      triggers:
+      - type: ConfigChange
+      - type: ImageChange
+        imageChangeParams:
+          automatic: true
+          containerNames:
+          - mgmt
+          from:
+            kind: ImageStreamTag
+            name: "{{ mgmt_image_name }}:{{ openshift_registry_tag }}"
+            namespace: "{{ openshift_namespace }}"

--- a/ansible/roles/wordpress-openshift-namespace/tasks/monitoring.yml
+++ b/ansible/roles/wordpress-openshift-namespace/tasks/monitoring.yml
@@ -3,107 +3,110 @@
 - name: Prometheus service
   openshift:
     state: latest
-    content: |
-      apiVersion: v1
-      kind: Service
-      metadata:
-        name: prometheus
-        namespace: "{{ openshift_namespace }}"
-        labels:
-          app: prometheus
-      spec:
-        ports:
-          - name: prometheus
-            port: 9090
-        selector:
-          app: prometheus
+    apiVersion: v1
+    kind: Service
+    metadata:
+      name: prometheus
+      namespace: "{{ openshift_namespace }}"
+      labels:
+        app: prometheus
+    spec:
+      ports:
+        - name: prometheus
+          port: 9090
+      selector:
+        app: prometheus
 
 - name: Prometheus route (https://prometheus-wwp.epfl.ch/)
   openshift:
     state: latest
-    content: |
-      apiVersion: route.openshift.io/v1
-      kind: Route
-      metadata:
+    apiVersion: route.openshift.io/v1
+    kind: Route
+    metadata:
+      name: prometheus
+      namespace: "{{ openshift_namespace }}"
+    spec:
+      host: prometheus-wwp.epfl.ch
+      port:
+        targetPort: prometheus
+      tls:
+        termination: edge
+      to:
+        kind: Service
         name: prometheus
-        namespace: "{{ openshift_namespace }}"
-      spec:
-        host: prometheus-wwp.epfl.ch
-        port:
-          targetPort: prometheus
-        tls:
-          termination: edge
-        to:
-          kind: Service
-          name: prometheus
 
 - name: Prometheus StatefulSet
   openshift:
     state: latest
-    content: |
-      apiVersion: apps/v1
-      kind: StatefulSet
-      metadata:
-        name: prometheus
-        namespace: "{{ openshift_namespace }}"
-        annotations:
-          # https://docs.openshift.com/container-platform/3.11/dev_guide/managing_images.html#image-stream-kubernetes-resources
-          image.openshift.io/triggers: '[{"from":{"kind":"ImageStreamTag","name":"{{ monitoring_prober_image_name }}:latest"},"fieldPath":"spec.template.spec.containers[?(@.name==\"prober\")].image"}]'
-      spec:
-        serviceName: prometheus  # Refs the service above, so that the pods get
-                                 # a predictable KubeDNS name
-        selector:
-          matchLabels:
+    apiVersion: apps/v1
+    kind: StatefulSet
+    metadata:
+      name: prometheus
+      namespace: "{{ openshift_namespace }}"
+      annotations:
+        # https://docs.openshift.com/container-platform/3.11/dev_guide/managing_images.html#image-stream-kubernetes-resources
+        image.openshift.io/triggers: >-
+          {{ [dict(from=
+                     dict(kind="ImageStreamTag",
+                          name=monitoring_prober_image_name + ":latest",
+                          fieldPath='spec.template.spec.'
+                                    'containers[?(@.name=="prober")].image')
+                  )] | to_json }}
+    spec:
+      serviceName: prometheus  # Refs the service above, so that the pods get
+                               # a predictable KubeDNS name
+      selector:
+        matchLabels:
+          app: prometheus
+      template:
+        metadata:
+          labels:
             app: prometheus
-        template:
-          metadata:
-            labels:
-              app: prometheus
-          spec:
-            terminationGracePeriodSeconds: 10
-            containers:
-              - name: prometheus
-                image: prom/prometheus
-                ports:
-                - containerPort: 9090
-                  name: prometheus
-                volumeMounts:
-                  - name: storage
-                    mountPath: /prometheus
-                  - name: dynamic-config
-                    mountPath: /prometheus-config/dynamic
-                  - name: static-config
-                    mountPath: /prometheus-config/static
-                command:
-                  - /bin/prometheus
-                  - --config.file=/prometheus-config/static/prometheus.yml
-                  - --storage.tsdb.path=/prometheus
-                  - --query.lookback-delta=15m     # Menu values change slowly
-                  - --web.console.libraries=/usr/share/prometheus/console_libraries
-                  - --web.console.templates=/usr/share/prometheus/consoles/prometheus
-              - name: configurator
-                image: python:3.7-alpine
-                volumeMounts:
-                  - name: dynamic-config
-                    mountPath: /prometheus-config/dynamic
-                  - name: static-config
-                    mountPath: /prometheus-config/static
-                command:
-                      - /usr/bin/env
-                      - python3
-                      - /prometheus-config/static/prometheus-menu-service-discovery.py
-              - name: prober
-                # image for this one is obtained by trigger (see
-                # above) from the ImageStreamTag
-                # This container is otherwise stateless
-            volumes:
-              - name: storage
-                emptyDir: {}  # TODO We probably want some persistence here
-              - name: dynamic-config
-                emptyDir: {}
-              - name: static-config
-                configMap:
-                  name: prometheus
+        spec:
+          terminationGracePeriodSeconds: 10
+          containers:
+            - name: prometheus
+              image: prom/prometheus
+              ports:
+              - containerPort: 9090
+                name: prometheus
+              volumeMounts:
+                - name: storage
+                  mountPath: /prometheus
+                - name: dynamic-config
+                  mountPath: /prometheus-config/dynamic
+                - name: static-config
+                  mountPath: /prometheus-config/static
+              command:
+                - /bin/prometheus
+                - --config.file=/prometheus-config/static/prometheus.yml
+                - --storage.tsdb.path=/prometheus
+                - --query.lookback-delta=15m     # Menu values change slowly
+                - --web.console.libraries=/usr/share/prometheus/console_libraries
+                - --web.console.templates=/usr/share/prometheus/consoles/prometheus
+            - name: configurator
+              image: python:3.7-alpine
+              volumeMounts:
+                - name: dynamic-config
+                  mountPath: /prometheus-config/dynamic
+                - name: static-config
+                  mountPath: /prometheus-config/static
+              command:
+                    - /usr/bin/env
+                    - python3
+                    - /prometheus-config/static/prometheus-menu-service-discovery.py
+            - name: prober
+              # image for this one is obtained by trigger (see
+              # above) from the ImageStreamTag
+              # This container is otherwise stateless
+          volumes:
+            - name: storage
+              emptyDir: {}  # TODO We probably want some persistence here
+            - name: dynamic-config
+              emptyDir: {}
+            - name: static-config
+              configMap:
+                name: prometheus
 
 - name: Prometheus ConfigMap (configuration and sync scripts)
   openshift:

--- a/ansible/roles/wordpress-openshift-namespace/vars/main.yml
+++ b/ansible/roles/wordpress-openshift-namespace/vars/main.yml
@@ -3,3 +3,5 @@
 
 openshift_is_production: "{{ openshift_namespace == 'wwp' }}"
 openshift_registry_tag: "{{ 'prod' if openshift_is_production else 'latest' }}"
+
+wwp_build_namespace: wwp-test


### PR DESCRIPTION
- Fully flesh out the `httpd` DeploymentConfig objects (test-side only, for now)
- Refactor to eliminate the "text" form of `openshift:` tasks; use actual YAML instead
- Rewrite decimal file modes into octal
