### PR TITLE
[fix] Small issues in the `wpsible` wrapper

### DIFF
--- a/ansible/inventory/wordpress-instances.py
+++ b/ansible/inventory/wordpress-instances.py
@@ -7,9 +7,15 @@
 # Example invocation:
 #    env WWP_INVENTORY_SOURCES=wpveritas,nfs WWP_NAMESPACES=wwp-test,wwp wordpress-instances.py
 
-import os
-import subprocess
 import sys
+import os
+
+suitcase_interpreter = os.path.join(os.path.dirname(__file__), os.path.pardir,
+                                    "ansible-deps-cache", "bin", "python3")
+if os.path.realpath(suitcase_interpreter) != os.path.realpath(sys.executable):
+    os.execl(suitcase_interpreter, suitcase_interpreter, *sys.argv)
+
+import subprocess
 import logging
 import re
 from functools import reduce

--- a/ansible/wpsible
+++ b/ansible/wpsible
@@ -53,7 +53,7 @@ platform_check () {
 }
 
 oc_check () {
-  if ! oc projects 2>/dev/null; then
+  if ! oc projects >/dev/null 2>&1; then
     echo "Please login to openshift:"
     oc login
   fi

--- a/ansible/wpsible
+++ b/ansible/wpsible
@@ -48,6 +48,8 @@ platform_check () {
     fi
     export PATH="$PWD/ansible-deps-cache/bin:$PATH"
     export ANSIBLE_ROLES_PATH="$PWD/ansible-deps-cache/roles"
+
+    oc_check
 }
 
 oc_check () {
@@ -101,7 +103,6 @@ set -e
 platform_check
 case "$mode" in
     ansible-playbook)
-        oc_check
         ansible-galaxy install -i -r requirements.yml >/dev/null 2>&1
         ansible-playbook $playbook_flags $(inventories) "${ansible_args[@]}" \
                          -e "wpsible_cwd=$OLDPWD" \

--- a/ansible/wpsible
+++ b/ansible/wpsible
@@ -98,9 +98,9 @@ esac
 
 set -e
 
+platform_check
 case "$mode" in
     ansible-playbook)
-        platform_check
         oc_check
         ansible-galaxy install -i -r requirements.yml >/dev/null 2>&1
         ansible-playbook $playbook_flags $(inventories) "${ansible_args[@]}" \


### PR DESCRIPTION
- Mute useless indications from `oc projects` (for versions >= 4.0)
- Ensure to run the Python inventory using the suitcase's Python interpreter (fixes #277)
- Equal opportunity for “playbook-less” invocations:
    - move oc_check call inside platform_check
    - do `platform_check` also in playbook-less mode
