### PR TITLE
[feature] manage inactive coming soon

### DIFF
--- a/ansible/roles/wordpress-instance/tasks/main.yml
+++ b/ansible/roles/wordpress-instance/tasks/main.yml
@@ -103,7 +103,7 @@
     - plugins.wp_media_folder_options
     - plugins.unknown
     - plugins.polylang
-    - plugins.coming-soon
+    - wp.plugins.coming-soon
     - plugins.intranet
     - plugins.intranet.htaccess
   include_tasks:

--- a/ansible/roles/wordpress-instance/tasks/main.yml
+++ b/ansible/roles/wordpress-instance/tasks/main.yml
@@ -103,6 +103,7 @@
     - plugins.wp_media_folder_options
     - plugins.unknown
     - plugins.polylang
+    - plugins.coming-soon
     - plugins.intranet
     - plugins.intranet.htaccess
   include_tasks:

--- a/ansible/roles/wordpress-instance/tasks/plugins.yml
+++ b/ansible/roles/wordpress-instance/tasks/plugins.yml
@@ -34,46 +34,39 @@
   register: _active_plugins
   changed_when: false
   check_mode: no
+  tags: always
 
-- name: Coming Soon plugin (only at creation time)
-  wordpress_plugin:
-    name: coming-soon
-    state:
-      - symlinked
-      - active
-    from: wordpress.org/plugins
-  when: >-
-    _active_plugins.stdout == ""
+- name: Was “coming soon” plug-in active?
+  check_mode: no   # That means yes
+  shell:
+    chdir: "{{ wp_dir }}"
+    cmd: wp plugin list --name=coming-soon --status=active --format=count
+  changed_when: false
+  tags: wp.plugins.coming-soon
+  register: _coming_soon_plugin_was_active
 
 - name: Coming Soon options
   wordpress_option: "{{ item }}"
   with_items: "{{ plugin_coming_soon_options }}"
+  vars:
+    plugin_coming_soon_shall_be_enabled: _coming_soon_plugin_was_active.stdout != "0"
   when: >-
     _active_plugins.stdout == ""
+    or
+    _coming_soon_plugin_was_active.stdout == "0"
+  # i.e. site is new, or plugin was already active.
+  # In all other cases, we leave whatever configuration was
+  # already in place (whether by user or Ansible) alone.
+  tags: wp.plugins.coming-soon
 
-- name: Get Coming Soon plugin status
-  shell:
-    chdir: "{{ wp_dir }}"
-    cmd: "wp plugin list --name=coming-soon --status=inactive --format=count"
-  register: _inactive_cs_plugin
-  changed_when: false
-  tags: plugins.coming-soon
-
-- name: Disable Coming Soon options
-  wordpress_option: "{{ item }}"
-  with_items: "{{ disable_plugin_coming_soon_options }}"
-  when: _inactive_cs_plugin.stdout == "1"
-  tags: plugins.coming-soon
-
-- name: Coming Soon plugin (only if inactive)
+- name: Coming Soon plugin (always installed)
   wordpress_plugin:
     name: coming-soon
     state:
       - symlinked
       - active
     from: wordpress.org/plugins
-  when: _inactive_cs_plugin.stdout == "1"
-  tags: plugins.coming-soon
+  tags: wp.plugins.coming-soon
 
 ##################### Must-use plugins ###########################
 

--- a/ansible/roles/wordpress-instance/tasks/plugins.yml
+++ b/ansible/roles/wordpress-instance/tasks/plugins.yml
@@ -51,6 +51,30 @@
   when: >-
     _active_plugins.stdout == ""
 
+- name: Get Coming Soon plugin status
+  shell:
+    chdir: "{{ wp_dir }}"
+    cmd: "wp plugin list --name=coming-soon --status=inactive --format=count"
+  register: _inactive_cs_plugin
+  changed_when: false
+  tags: plugins.coming-soon
+
+- name: Disable Coming Soon options
+  wordpress_option: "{{ item }}"
+  with_items: "{{ disable_plugin_coming_soon_options }}"
+  when: _inactive_cs_plugin.stdout == "1"
+  tags: plugins.coming-soon
+
+- name: Coming Soon plugin (only if inactive)
+  wordpress_plugin:
+    name: coming-soon
+    state:
+      - symlinked
+      - active
+    from: wordpress.org/plugins
+  when: _inactive_cs_plugin.stdout == "1"
+  tags: plugins.coming-soon
+
 ##################### Must-use plugins ###########################
 
 - name: Custom editor menu (must-use plugin)

--- a/ansible/roles/wordpress-instance/tasks/plugins.yml
+++ b/ansible/roles/wordpress-instance/tasks/plugins.yml
@@ -49,12 +49,12 @@
   wordpress_option: "{{ item }}"
   with_items: "{{ plugin_coming_soon_options }}"
   vars:
-    plugin_coming_soon_shall_be_enabled: _coming_soon_plugin_was_active.stdout != "0"
+    - plugin_coming_soon_shall_be_disabled: '{{ (_coming_soon_plugin_was_active.stdout == "0") and (_active_plugins.stdout != "") }}'
   when: >-
     _active_plugins.stdout == ""
     or
     _coming_soon_plugin_was_active.stdout == "0"
-  # i.e. site is new, or plugin was already active.
+  # i.e. site is new, or plugin was already inactive.
   # In all other cases, we leave whatever configuration was
   # already in place (whether by user or Ansible) alone.
   tags: wp.plugins.coming-soon

--- a/ansible/roles/wordpress-instance/tasks/plugins.yml
+++ b/ansible/roles/wordpress-instance/tasks/plugins.yml
@@ -69,7 +69,7 @@
   vars:
     plugin_coming_soon_shall_be_enabled: false
   when: >-
-    _coming_soon_plugin_was_active.stdout == "0"
+    _active_plugins.stdout != "" and _coming_soon_plugin_was_active.stdout == "0"
   tags: wp.plugins.coming-soon
 
 - name: Coming Soon plugin (always installed)

--- a/ansible/roles/wordpress-instance/tasks/plugins.yml
+++ b/ansible/roles/wordpress-instance/tasks/plugins.yml
@@ -45,18 +45,31 @@
   tags: wp.plugins.coming-soon
   register: _coming_soon_plugin_was_active
 
-- name: Coming Soon options
+- name: Enable Coming Soon on new sites
   wordpress_option: "{{ item }}"
   with_items: "{{ plugin_coming_soon_options }}"
   vars:
-    - plugin_coming_soon_shall_be_disabled: '{{ (_coming_soon_plugin_was_active.stdout == "0") and (_active_plugins.stdout != "") }}'
+    plugin_coming_soon_shall_be_enabled: true
   when: >-
     _active_plugins.stdout == ""
-    or
+
+# We changed the standard operating procedure around mid-2020
+# regarding Coming Soon's configuration management. Turning it off
+# through its configuration (as opposed to uninstalling the plug-in,
+# as we did before) empowers the user and lets them turn Coming Soon
+# mode back on at will. The following task is intended to migrate
+# WordPress sites to the new way of doing things, without turning
+# Coming Soon back on inadvertently (in case the old config was still
+# lingering in the wp_options table despite the plug-in having been
+# uninstalled). Once this task has run on the entire fleet, it ought
+# to be removed.
+- name: Disable Coming Soon on sites where the plug-in was previously inactive
+  wordpress_option: "{{ item }}"
+  with_items: "{{ plugin_coming_soon_options }}"
+  vars:
+    plugin_coming_soon_shall_be_enabled: false
+  when: >-
     _coming_soon_plugin_was_active.stdout == "0"
-  # i.e. site is new, or plugin was already inactive.
-  # In all other cases, we leave whatever configuration was
-  # already in place (whether by user or Ansible) alone.
   tags: wp.plugins.coming-soon
 
 - name: Coming Soon plugin (always installed)

--- a/ansible/roles/wordpress-instance/vars/plugin-vars.yml
+++ b/ansible/roles/wordpress-instance/vars/plugin-vars.yml
@@ -55,6 +55,11 @@ plugin_coming_soon_options:
   - name: seed_csp4_settings_content
     value: 'a:9:{s:6:"status";s:1:"1";s:4:"logo";s:76:"https://www.epfl.ch/wp-content/themes/wp-theme-2018/assets/svg/epfl-logo.svg";s:8:"headline";s:26:"Something new is coming...";s:11:"description";s:301:"&nbsp;<div class="footer-content"><nav class="footer-navigation" role="navigation"></nav><p class="site-admin" style="position:absolute;bottom:0;width:50%;text-align:right;"><span style="font-size:10pt;font-family:arial,helvetica,sans-serif;"><a href="wp-admin/">Connexion / Login</a></span></p></div>";s:13:"footer_credit";s:1:"0";s:7:"favicon";s:0:"";s:9:"seo_title";s:0:"";s:15:"seo_description";s:0:"";s:12:"ga_analytics";s:0:"";}'
 
+# Disable Coming Soon
+disable_plugin_coming_soon_options:
+  - name: seed_csp4_settings_content
+    value: 'a:9:{s:6:"status";s:1:"0";s:4:"logo";s:76:"https://www.epfl.ch/wp-content/themes/wp-theme-2018/assets/svg/epfl-logo.svg";s:8:"headline";s:26:"Something new is coming...";s:11:"description";s:301:"&nbsp;<div class="footer-content"><nav class="footer-navigation" role="navigation"></nav><p class="site-admin" style="position:absolute;bottom:0;width:50%;text-align:right;"><span style="font-size:10pt;font-family:arial,helvetica,sans-serif;"><a href="wp-admin/">Connexion / Login</a></span></p></div>";s:13:"footer_credit";s:1:"0";s:7:"favicon";s:0:"";s:9:"seo_title";s:0:"";s:15:"seo_description";s:0:"";s:12:"ga_analytics";s:0:"";}'
+
 # WP Media Folder
 plugin_wpmf_options:
   - name: wpmf_use_taxonomy

--- a/ansible/roles/wordpress-instance/vars/plugin-vars.yml
+++ b/ansible/roles/wordpress-instance/vars/plugin-vars.yml
@@ -46,19 +46,14 @@ plugin_cache_control_options:
   - name: cache_control_pages_max_age
     value: 300
 
-# Coming Soon
+# Coming Soon - Depends on template-supplied variable "plugin_coming_soon_shall_be_enabled"
 plugin_coming_soon_options:
   - name: seed_csp4_settings_design
     value: 'a:13:{s:8:"bg_color";s:0:"";s:8:"bg_image";s:0:"";s:8:"bg_cover";a:1:{i:0;s:1:"1";}s:7:"bg_size";s:5:"cover";s:9:"bg_repeat";s:9:"no-repeat";s:11:"bg_position";s:8:"left top";s:13:"bg_attahcment";s:5:"fixed";s:9:"max_width";s:0:"";s:10:"text_color";s:7:"#666666";s:10:"link_color";s:7:"#000000";s:14:"headline_color";s:7:"#e2001a";s:9:"text_font";s:6:"_arial";s:10:"custom_css";s:0:"";}'
   - name: seed_csp4_review
     value: 'a:2:{s:4:"time";i:1523968292;s:9:"dismissed";b:1;}'
   - name: seed_csp4_settings_content
-    value: 'a:9:{s:6:"status";s:1:"1";s:4:"logo";s:76:"https://www.epfl.ch/wp-content/themes/wp-theme-2018/assets/svg/epfl-logo.svg";s:8:"headline";s:26:"Something new is coming...";s:11:"description";s:301:"&nbsp;<div class="footer-content"><nav class="footer-navigation" role="navigation"></nav><p class="site-admin" style="position:absolute;bottom:0;width:50%;text-align:right;"><span style="font-size:10pt;font-family:arial,helvetica,sans-serif;"><a href="wp-admin/">Connexion / Login</a></span></p></div>";s:13:"footer_credit";s:1:"0";s:7:"favicon";s:0:"";s:9:"seo_title";s:0:"";s:15:"seo_description";s:0:"";s:12:"ga_analytics";s:0:"";}'
-
-# Disable Coming Soon
-disable_plugin_coming_soon_options:
-  - name: seed_csp4_settings_content
-    value: 'a:9:{s:6:"status";s:1:"0";s:4:"logo";s:76:"https://www.epfl.ch/wp-content/themes/wp-theme-2018/assets/svg/epfl-logo.svg";s:8:"headline";s:26:"Something new is coming...";s:11:"description";s:301:"&nbsp;<div class="footer-content"><nav class="footer-navigation" role="navigation"></nav><p class="site-admin" style="position:absolute;bottom:0;width:50%;text-align:right;"><span style="font-size:10pt;font-family:arial,helvetica,sans-serif;"><a href="wp-admin/">Connexion / Login</a></span></p></div>";s:13:"footer_credit";s:1:"0";s:7:"favicon";s:0:"";s:9:"seo_title";s:0:"";s:15:"seo_description";s:0:"";s:12:"ga_analytics";s:0:"";}'
+    value: 'a:9:{s:6:"status";s:1:"{{ "1" if plugin_coming_soon_shall_be_enabled else "0" }}";s:4:"logo";s:76:"https://www.epfl.ch/wp-content/themes/wp-theme-2018/assets/svg/epfl-logo.svg";s:8:"headline";s:26:"Something new is coming...";s:11:"description";s:301:"&nbsp;<div class="footer-content"><nav class="footer-navigation" role="navigation"></nav><p class="site-admin" style="position:absolute;bottom:0;width:50%;text-align:right;"><span style="font-size:10pt;font-family:arial,helvetica,sans-serif;"><a href="wp-admin/">Connexion / Login</a></span></p></div>";s:13:"footer_credit";s:1:"0";s:7:"favicon";s:0:"";s:9:"seo_title";s:0:"";s:15:"seo_description";s:0:"";s:12:"ga_analytics";s:0:"";}'
 
 # WP Media Folder
 plugin_wpmf_options:

--- a/ansible/roles/wordpress-instance/vars/plugin-vars.yml
+++ b/ansible/roles/wordpress-instance/vars/plugin-vars.yml
@@ -53,7 +53,7 @@ plugin_coming_soon_options:
   - name: seed_csp4_review
     value: 'a:2:{s:4:"time";i:1523968292;s:9:"dismissed";b:1;}'
   - name: seed_csp4_settings_content
-    value: 'a:9:{s:6:"status";s:1:"{{ "1" if plugin_coming_soon_shall_be_enabled else "0" }}";s:4:"logo";s:76:"https://www.epfl.ch/wp-content/themes/wp-theme-2018/assets/svg/epfl-logo.svg";s:8:"headline";s:26:"Something new is coming...";s:11:"description";s:301:"&nbsp;<div class="footer-content"><nav class="footer-navigation" role="navigation"></nav><p class="site-admin" style="position:absolute;bottom:0;width:50%;text-align:right;"><span style="font-size:10pt;font-family:arial,helvetica,sans-serif;"><a href="wp-admin/">Connexion / Login</a></span></p></div>";s:13:"footer_credit";s:1:"0";s:7:"favicon";s:0:"";s:9:"seo_title";s:0:"";s:15:"seo_description";s:0:"";s:12:"ga_analytics";s:0:"";}'
+    value: 'a:9:{s:6:"status";s:1:"{{ plugin_coming_soon_shall_be_disabled | ternary("0", "1") }}";s:4:"logo";s:76:"https://www.epfl.ch/wp-content/themes/wp-theme-2018/assets/svg/epfl-logo.svg";s:8:"headline";s:26:"Something new is coming...";s:11:"description";s:301:"&nbsp;<div class="footer-content"><nav class="footer-navigation" role="navigation"></nav><p class="site-admin" style="position:absolute;bottom:0;width:50%;text-align:right;"><span style="font-size:10pt;font-family:arial,helvetica,sans-serif;"><a href="wp-admin/">Connexion / Login</a></span></p></div>";s:13:"footer_credit";s:1:"0";s:7:"favicon";s:0:"";s:9:"seo_title";s:0:"";s:15:"seo_description";s:0:"";s:12:"ga_analytics";s:0:"";}'
 
 # WP Media Folder
 plugin_wpmf_options:

--- a/ansible/roles/wordpress-instance/vars/plugin-vars.yml
+++ b/ansible/roles/wordpress-instance/vars/plugin-vars.yml
@@ -53,7 +53,7 @@ plugin_coming_soon_options:
   - name: seed_csp4_review
     value: 'a:2:{s:4:"time";i:1523968292;s:9:"dismissed";b:1;}'
   - name: seed_csp4_settings_content
-    value: 'a:9:{s:6:"status";s:1:"{{ plugin_coming_soon_shall_be_disabled | ternary("0", "1") }}";s:4:"logo";s:76:"https://www.epfl.ch/wp-content/themes/wp-theme-2018/assets/svg/epfl-logo.svg";s:8:"headline";s:26:"Something new is coming...";s:11:"description";s:301:"&nbsp;<div class="footer-content"><nav class="footer-navigation" role="navigation"></nav><p class="site-admin" style="position:absolute;bottom:0;width:50%;text-align:right;"><span style="font-size:10pt;font-family:arial,helvetica,sans-serif;"><a href="wp-admin/">Connexion / Login</a></span></p></div>";s:13:"footer_credit";s:1:"0";s:7:"favicon";s:0:"";s:9:"seo_title";s:0:"";s:15:"seo_description";s:0:"";s:12:"ga_analytics";s:0:"";}'
+    value: 'a:9:{s:6:"status";s:1:"{{ plugin_coming_soon_shall_be_enabled | ternary("1", "0") }}";s:4:"logo";s:76:"https://www.epfl.ch/wp-content/themes/wp-theme-2018/assets/svg/epfl-logo.svg";s:8:"headline";s:26:"Something new is coming...";s:11:"description";s:301:"&nbsp;<div class="footer-content"><nav class="footer-navigation" role="navigation"></nav><p class="site-admin" style="position:absolute;bottom:0;width:50%;text-align:right;"><span style="font-size:10pt;font-family:arial,helvetica,sans-serif;"><a href="wp-admin/">Connexion / Login</a></span></p></div>";s:13:"footer_credit";s:1:"0";s:7:"favicon";s:0:"";s:9:"seo_title";s:0:"";s:15:"seo_description";s:0:"";s:12:"ga_analytics";s:0:"";}'
 
 # WP Media Folder
 plugin_wpmf_options:


### PR DESCRIPTION
Cette PR (Fix #280 ) a pour but d'activer et de "désarmer" (settings: disabled) le plugin coming-soon si ce dernier est inactif.

Voila, un petit schéma qui permet de mieux comprendre les différents cas gérés par Ansible pour ce plugin:

![coming-soon-workflow](https://user-images.githubusercontent.com/4997224/86019482-f3cc5680-ba26-11ea-9264-fca5f8d98de2.png)

Schéma: @ponsfrilus 