### PR TITLE
[fix] AWX was broken in multiple ways

### DIFF
--- a/ansible/inventory/wordpress-instances.py
+++ b/ansible/inventory/wordpress-instances.py
@@ -12,7 +12,8 @@ import os
 
 suitcase_interpreter = os.path.join(os.path.dirname(__file__), os.path.pardir,
                                     "ansible-deps-cache", "bin", "python3")
-if os.path.realpath(suitcase_interpreter) != os.path.realpath(sys.executable):
+if (os.path.exists(suitcase_interpreter) and
+    os.path.realpath(suitcase_interpreter) != os.path.realpath(sys.executable)):
     os.execl(suitcase_interpreter, suitcase_interpreter, *sys.argv)
 
 import subprocess

--- a/ansible/roles/awx-instance/tasks/k8s-builds.yml
+++ b/ansible/roles/awx-instance/tasks/k8s-builds.yml
@@ -19,10 +19,13 @@
     dockerfile: |
       FROM docker-registry.default.svc:5000/{{ ansible_oc_namespace }}/{{ wp_base_image_name }}:latest
       FROM docker-registry.default.svc:5000/{{ ansible_oc_namespace }}/{{ awx_runner_base_image_name }}:latest
-      RUN yum -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
-      RUN yum -y install http://rpms.remirepo.net/enterprise/remi-release-7.rpm
-      RUN yum-config-manager --disable remi-php54 && \
-          yum-config-manager --enable remi-php73
+
+      RUN yum -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm
+
+      RUN yum -y install http://rpms.remirepo.net/enterprise/remi-release-8.rpm
+
+      RUN dnf module enable php:remi-7.3 -y
+
       RUN yum -y install php-cli php-mysql python3
 
       COPY --from=0 /usr/local/bin/wp /usr/local/bin/
@@ -37,9 +40,6 @@
       RUN groupadd -g {{ awx_unix_credentials.gid }} {{ awx_unix_credentials.group }}
       RUN useradd -u {{ awx_unix_credentials.uid }} -g {{ awx_unix_credentials.gid }} -d /runner {{ awx_unix_credentials.user }}
       RUN chgrp -R {{ awx_unix_credentials.group }} /runner
-
-      # Work around https://github.com/ansible/awx/issues/2893
-      RUN yum -y install patch curl; curl https://github.com/domq/ansible-runner/commit/06f38faffd546d0d25c7708fa77a97d6e882a1bd.patch | patch -p1 /usr/lib/python2.7/site-packages/ansible_runner/runner.py
 
 - name: "Rebuild {{ awx_runner_image_name }} now"
   when: _awx_runner_buildconfig is changed

--- a/ansible/roles/awx-instance/tasks/k8s-builds.yml
+++ b/ansible/roles/awx-instance/tasks/k8s-builds.yml
@@ -24,7 +24,7 @@
 
       RUN yum -y install http://rpms.remirepo.net/enterprise/remi-release-8.rpm
 
-      RUN dnf module enable php:remi-7.3 -y
+      RUN dnf module enable php:remi-7.4 -y
 
       RUN yum -y install php-cli php-mysql python3
 


### PR DESCRIPTION
- Build the awx-runner on top of the new, RH8-based image
- Inventory script should not attempt to run through [ansible-suitcase](https://github.com/epfl-si/ansible.suitcase) on AWX, because it is not available there
