### PR TITLE
[add] Custom lnav parser for our Apache logs

### DIFF
--- a/docker/mgmt/Dockerfile
+++ b/docker/mgmt/Dockerfile
@@ -42,6 +42,9 @@ COPY new-wp-site.sh /usr/local/bin/new-wp-site
 RUN chmod a+x /usr/local/bin/new-wp-site
 COPY ./docker-entrypoint.sh /
 
+# lnav custom file formats
+COPY lnav /var/www/.lnav/formats/epfl
+
 ARG WP_OPS_BRANCH=master
 RUN set -e -x; cd /wp; git clone https://github.com/epfl-si/wp-ops; \
     cd wp-ops; git checkout ${WP_OPS_BRANCH}

--- a/docker/mgmt/lnav/apache-hostname-leading.json
+++ b/docker/mgmt/lnav/apache-hostname-leading.json
@@ -1,0 +1,10 @@
+{
+    "access_log" : {
+        "regex" : {
+            "apache-hostname-leading" : {
+                "pattern" : "^\\w+ (?<c_ip>[\\w\\.:\\-]+)\\s+[\\w\\.\\-]+\\s+(?<cs_username>\\S+)\\s+\\[(?<timestamp>[^\\]]+)\\] \"(?:\\-|(?<cs_method>\\w+) (?<cs_uri_stem>[^ \\?]+)(?:\\?(?<cs_uri_query>[^ ]*))? (?<cs_version>[\\w/\\.]+))\" (?<sc_status>\\d+) (?<sc_bytes>\\d+|-)(?: \"(?<cs_referer>[^\"]+)\" \"(?<cs_user_agent>[^\"]+)\")?\\s*(?<body>.*)"
+            }
+        }
+    }
+}
+


### PR DESCRIPTION
WordPress logs uses the so-called "vcommon" Apache log format, with
the name of the serving virtual host as an additional field in first
position. lnav won't grok these, unless taught how, so there.

- Snarf JSON file found at
https://groups.google.com/g/lnav/c/aWLs2PCTtVU/m/1WkvoW7OAwAJ

- Arrange for the mgmt Docker image to have it