### PR TITLE
[fix] Skipping the WordPress instance role vs. --skip-tags

### DIFF
--- a/ansible/.interactive-playbooks/filter_plugins/tags.py
+++ b/ansible/.interactive-playbooks/filter_plugins/tags.py
@@ -22,7 +22,7 @@ class FilterModule(object):
             return True
         else:
             return bool(
-                tags.intersection(set(self.find_role_tags(role_path))))
+                tags.intersection(set(self.find_all_tags(role_path))))
 
     def find_all_tags(self, role_path):
         return list(_TagShaker.of(os.path.join(role_path, 'tasks')).get_role_tags())

--- a/ansible/.interactive-playbooks/main.yml
+++ b/ansible/.interactive-playbooks/main.yml
@@ -26,8 +26,10 @@
     - name: WordPress instances
       include_role:
         name: ../roles/wordpress-instance
-      tags: >-
-        {{ ( (playbook_dir | dirname) + "/roles/wordpress-instance" ) | find_all_tags }}
+      when: >-
+        ansible_run_tags |
+        any_known_tag((playbook_dir | dirname) + "/roles/wordpress-instance")
+      tags: always  # That is, let the `when` clause above make the decision
 
 - name: OpenShift namespaces
   # Like above, members of the all_openshift_namespaces are OpenShift


### PR DESCRIPTION
Make `--skip-tags` work nicely with the role skip feature.

<img width="941" alt="image" src="https://user-images.githubusercontent.com/1629585/88035830-fe1fd300-cb42-11ea-885b-c8f704322782.png">

Picture obtained with

```
./ansible/wpsible -l test_migration_wp__labs__urbangene -e '{"wp_destructive": {"test_migration_wp__labs__urbangene": ["config"]}, "wp_version_lineage": "5.4"}' --skip-tags plugins,themes
```
