### PR TITLE
[fix] `--check` support

### DIFF
--- a/ansible/roles/wordpress-instance/tasks/configure.yml
+++ b/ansible/roles/wordpress-instance/tasks/configure.yml
@@ -78,8 +78,11 @@
   shell:
     cmd: |
       {{ wp_cli_command }} core update-db
-  when: >
-    "already" not in _wp_core_db_update_dry_run.stdout
+  when:
+    - |
+      not _wp_core_db_update_dry_run.skipped
+    - |
+      "already" not in _wp_core_db_update_dry_run.stdout
 
 - name: Check whether ping_sites is set
   command: "{{ wp_cli_command }} option get ping_sites"

--- a/ansible/roles/wordpress-instance/tasks/samples.yml
+++ b/ansible/roles/wordpress-instance/tasks/samples.yml
@@ -5,7 +5,9 @@
 
 - name: Delete sample page
   command: "{{ wp_cli_command }} post delete 2 --force"
-  when: _sample_page_id.stdout == "2"
+  when:
+    - not _sample_page_id.skipped
+    - _sample_page_id.stdout == "2"
   register: _page_delete
   changed_when: >-
     "stdout" in _page_delete and "Success" in _page_delete.stdout
@@ -17,7 +19,9 @@
 
 - name: Delete sample post
   command: "{{ wp_cli_command }} post delete 1 --force"
-  when: _sample_post_id.stdout == "1"
+  when:
+    - not _sample_post_id.skipped
+    - _sample_post_id.stdout == "1"
   register: _post_delete
   changed_when: >-
     "stdout" in _post_delete and "Success" in _post_delete.stdout

--- a/ansible/roles/wordpress-instance/tasks/site-metadata.yml
+++ b/ansible/roles/wordpress-instance/tasks/site-metadata.yml
@@ -6,8 +6,11 @@
 # Set the site's title to whatever is defined in wp-veritas if it was not changed since the WordPress installation
 - name: Set site title
   command: "{{ wp_cli_command }} option update blogname '{{ lookup('wpveritas', 'title') }}'"
-  when: |
-    _site_title.stdout == (wp_dir | basename)
+  when:
+    - |
+      not _site_title.skipped
+    - |
+      _site_title.stdout == (wp_dir | basename)
   register: _site_title_changed
   changed_when: |
     "option is unchanged" not in _site_title_changed.stdout
@@ -20,8 +23,11 @@
 # Set the tagline to whatever is defined in wp-veritas if it was not changed since the WordPress installation
 - name: Set tagline
   command: "{{ wp_cli_command }} option update blogdescription '{{ lookup('wpveritas', 'tagline') }}'"
-  when: |
-    _site_tagline.stdout == 'Just another WordPress site'
+  when:
+    - |
+      not _site_tagline.skipped
+    - |
+      _site_tagline.stdout == 'Just another WordPress site'
   register: _site_tagline_changed
   changed_when: |
     "option is unchanged" not in _site_tagline_changed.stdout


### PR DESCRIPTION
When a `when:` clause depends on the `.stdout` of a former command, do
check that that command was not `.skipped`