### PR TITLE
[feature] Unpin WordPress version

### DIFF
--- a/docker/wp-base/symlink-wp-versions.sh
+++ b/docker/wp-base/symlink-wp-versions.sh
@@ -25,9 +25,3 @@ do
             ;;
     esac
 done
-
-# As a backward compatibility measure / temporary hack, we support
-# sites that symlink to /wp instead of /wp/4 or /wp/5:
-for file_or_dir in 4/*; do
-    ln -s $file_or_dir .
-done

--- a/docker/wp-base/symlink-wp-versions.sh
+++ b/docker/wp-base/symlink-wp-versions.sh
@@ -6,18 +6,14 @@ cd /wp
 
 for version in *;   # Sorted by version since the 1970s
 do
-    major="$(echo "$version" |cut -d. -f1)"
-    majorminor="$(echo "$version" |cut -d. -f1-2)"
+    major="$(echo "$version" |cut -d. -f1)"         # e.g. 5
+    majorminor="$(echo "$version" |cut -d. -f1-2)"  # e.g. 5.2
 
-    # e.g. 5 -> 5.2.4 (except for 5.3 which is not ready for prime time)
-    case "$majorminor" in
-        4*|5.2)
-            rm -f "$major"                # best version wins, thanks to sorting order
-            ln -s "$version" "$major"
-            ;;
-    esac
+    rm -f "$major"
+    ln -s "$version" "$major"     # e.g. 5 -> 5.4  - Best version wins (i.e. runs last),
+                                  # thanks to sorting order
 
-    # e.g. 5.2 -> 5.2.4 (again except for the "real" 5.3, which doesn't have a patch level yet)
+    # e.g. 5.2 -> 5.2.4
     case "$version" in
         *.*.*)
             rm -f "$majorminor"


### PR DESCRIPTION
Now `/wp/5` points to `/wp/5.4`

Also, remove the WordPress 4.x living (by symlink) directly under `/wp`
