### PR TITLE
Add PDF plugin flipbook

### DIFF
--- a/ansible/roles/wordpress-instance/tasks/plugins.yml
+++ b/ansible/roles/wordpress-instance/tasks/plugins.yml
@@ -188,6 +188,14 @@
       - active
     from: wordpress.org/plugins
 
+- name: Gutenberg PDF Flipbook
+  wordpress_plugin:
+    name: flowpaper-lite-pdf-flipbook
+    state:
+      - symlinked
+      - active
+    from: wordpress.org/plugins
+
 # TODO: recapture intent of jahia2wp's
 # src/wordpress/plugins/custom/polylang.py
 # (perhaps not in this file)


### PR DESCRIPTION
Ajout d'un plugin PDF Flipbook. Ce plugin utilise un shortcode et n'a aucune interface utilisateur graphique donc l'ajouter sera complètement transparent pour l'utilisateur
Par la suite viendra un nouveau bloc qui fera office d'interface pour utiliser ce shortcode. 