### PR TITLE
[quickfix] Ansible `.skipped` return value only present when true

### DIFF
--- a/ansible/roles/wordpress-instance/tasks/configure.yml
+++ b/ansible/roles/wordpress-instance/tasks/configure.yml
@@ -80,7 +80,7 @@
       {{ wp_cli_command }} core update-db
   when:
     - |
-      not _wp_core_db_update_dry_run.skipped
+      not "skipped" in _wp_core_db_update_dry_run or ("skipped" in _wp_core_db_update_dry_run and not _wp_core_db_update_dry_run.skipped)
     - |
       "already" not in _wp_core_db_update_dry_run.stdout
 

--- a/ansible/roles/wordpress-instance/tasks/samples.yml
+++ b/ansible/roles/wordpress-instance/tasks/samples.yml
@@ -6,8 +6,10 @@
 - name: Delete sample page
   command: "{{ wp_cli_command }} post delete 2 --force"
   when:
-    - not _sample_page_id.skipped
-    - _sample_page_id.stdout == "2"
+    - |
+      not "skipped" in _sample_page_id or ("skipped" in _sample_page_id and not _sample_page_id.skipped)
+    - |
+      "stdout" in _sample_page_id and _sample_page_id.stdout == "2"
   register: _page_delete
   changed_when: >-
     "stdout" in _page_delete and "Success" in _page_delete.stdout
@@ -20,8 +22,10 @@
 - name: Delete sample post
   command: "{{ wp_cli_command }} post delete 1 --force"
   when:
-    - not _sample_post_id.skipped
-    - _sample_post_id.stdout == "1"
+    - |
+      not "skipped" in _sample_post_id or ("skipped" in _sample_post_id and not _sample_post_id.skipped)
+    - |
+      "stdout" in _sample_post_id and _sample_post_id.stdout == "1"
   register: _post_delete
   changed_when: >-
     "stdout" in _post_delete and "Success" in _post_delete.stdout
@@ -33,7 +37,9 @@
 
 - name: Delete Privacy Policy page
   command: "{{ wp_cli_command }} post delete 3 --force"
-  when: _privacy_policy_page_id.stdout == "3"
+  when:
+    - |
+      "stdout" in _privacy_policy_page_id and _privacy_policy_page_id.stdout == "3"
   register: _privacy_policy_page_delete
   changed_when: >-
     "stdout" in _privacy_policy_page_delete and "Success" in _privacy_policy_page_delete.stdout

--- a/ansible/roles/wordpress-instance/tasks/site-metadata.yml
+++ b/ansible/roles/wordpress-instance/tasks/site-metadata.yml
@@ -8,7 +8,7 @@
   command: "{{ wp_cli_command }} option update blogname '{{ lookup('wpveritas', 'title') }}'"
   when:
     - |
-      not _site_title.skipped
+      not "skipped" in _site_title or ("skipped" in _site_title and not _site_title.skipped)
     - |
       _site_title.stdout == (wp_dir | basename)
   register: _site_title_changed
@@ -25,7 +25,7 @@
   command: "{{ wp_cli_command }} option update blogdescription '{{ lookup('wpveritas', 'tagline') }}'"
   when:
     - |
-      not _site_tagline.skipped
+      not "skipped" in _site_tagline or ("skipped" in _site_tagline and not _site_tagline.skipped)
     - |
       _site_tagline.stdout == 'Just another WordPress site'
   register: _site_tagline_changed

--- a/ansible/roles/wordpress-instance/tasks/site-metadata.yml
+++ b/ansible/roles/wordpress-instance/tasks/site-metadata.yml
@@ -10,7 +10,7 @@
     - |
       not "skipped" in _site_title or ("skipped" in _site_title and not _site_title.skipped)
     - |
-      _site_title.stdout == (wp_dir | basename)
+      "stdout" in _site_title and _site_title.stdout == (wp_dir | basename)
   register: _site_title_changed
   changed_when: |
     "option is unchanged" not in _site_title_changed.stdout
@@ -27,7 +27,7 @@
     - |
       not "skipped" in _site_tagline or ("skipped" in _site_tagline and not _site_tagline.skipped)
     - |
-      _site_tagline.stdout == 'Just another WordPress site'
+      "stdout" in _site_tagline and _site_tagline.stdout == 'Just another WordPress site'
   register: _site_tagline_changed
   changed_when: |
     "option is unchanged" not in _site_tagline_changed.stdout


### PR DESCRIPTION
AFAICT the `.skipped` value is only present when true (i.e. when running Ansible with the `--check` argument), so one needs to check that it exists before using it. I haven't found something on it in the documentation, but you can start here https://docs.ansible.com/ansible/latest/reference_appendices/common_return_values.html#skipped.