### PR TITLE
[feature] symlink wpforms

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,7 @@ script:
   docker build \
      --build-arg "GITHUB_API_USER=${GITHUB_API_USER}"           \
      --build-arg "GITHUB_API_TOKEN=${GITHUB_API_TOKEN}"         \
-     --build-arg "INSTALL_AUTO_FLAGS=--exclude=wp-media-folder --exclude=wpforms --exclude=wpforms-epfl-payonline $wp_base_branch_build_arg" \
+     --build-arg "INSTALL_AUTO_FLAGS=--exclude=wp-media-folder --exclude=wpforms $wp_base_branch_build_arg" \
      -t epflsi/os-wp-base docker/wp-base
   docker build $mgmt_build_args \
      -t epflsi/os-wp-mgmt docker/mgmt

--- a/ansible/roles/wordpress-instance/tasks/plugins.yml
+++ b/ansible/roles/wordpress-instance/tasks/plugins.yml
@@ -615,9 +615,7 @@
   wordpress_plugin:
     name: wpforms-epfl-payonline
     state: "{{ plugins_for_payonline_category }}"
-    from: https://github.com/epfl-si/wpforms-epfl-payonline/archive/v1.0.3.zip
-    # https://github.com/epfl-si/wpforms-epfl-payonline/releases/latest/download/wpforms-epfl-payonline.zip
-    # Specific release: https://github.com/epfl-si/wpforms-epfl-payonline/releases/download/v1.0.2/wpforms-epfl-payonline.zip
+    from: https://github.com/epfl-si/wpforms-epfl-payonline/releases/latest/download/wpforms-epfl-payonline.zip
   tags:
     - wp.plugins.wpforms
     - wp.plugins.payonline

--- a/ansible/roles/wordpress-instance/vars/plugin-vars.yml
+++ b/ansible/roles/wordpress-instance/vars/plugin-vars.yml
@@ -23,7 +23,7 @@ plugins_for_library_category: '{{ [ "symlinked", "active" ] if "Library" in wp_s
 plugins_for_restauration_category: '{{ [ "symlinked", "active" ] if "Restauration" in wp_site_categories else "absent" }}'
 plugins_for_inside_category: '{{ ["symlinked", "active"] if "Inside" in wp_site_categories else "absent" }}'
 plugins_for_admin_category: '{{ [ "symlinked", "active" ] if "Admin" in wp_site_categories else "absent" }}'
-plugins_for_wpforms_category: '{{ [ "symlinked", "active" ] if "WPForms" in wp_site_categories else "absent" }}'
+plugins_for_wpforms_category: '{{ [ "symlinked", "active" ] if ("WPForms" in wp_site_categories or "Payonline" in wp_site_categories) else "absent" }}'
 plugins_for_payonline_category: '{{ [ "symlinked", "active" ] if "Payonline" in wp_site_categories else "absent" }}'
 
 # Defining if WP is managed or not


### PR DESCRIPTION
This PR includes:
  - no more travis exclude of wpforms-epfl-payonline
  - wp-veritas categories "Payonline" add wpforms plugin as well
  - plugin wpforms-epfl-payonline now has a zip with a subfolder in it, so the [latest release download url](https://github.com/epfl-si/wpforms-epfl-payonline/releases/latest/download/wpforms-epfl-payonline.zip) can be used