### PR TITLE
Remove old PDF viewer

### DIFF
--- a/ansible/roles/wordpress-instance/tasks/plugins.yml
+++ b/ansible/roles/wordpress-instance/tasks/plugins.yml
@@ -181,14 +181,6 @@
       - active
     from: wordpress.org/plugins
 
-- name: Gutenberg PDF Viewer Block
-  wordpress_plugin:
-    name: pdf-viewer-block
-    state:
-      - symlinked
-      - active
-    from: wordpress.org/plugins
-
 - name: Gutenberg PDF Flipbook
   wordpress_plugin:
     name: flowpaper-lite-pdf-flipbook


### PR DESCRIPTION
Suite à l'ajout d'un autre élément pour afficher les PDF (#307 ) et à la transformation du code pour utiliser ce nouvel élément (https://github.com/epfl-si/jahia2wp/pull/1171), on peut supprimer l'ancien block 👋 