### PR TITLE
[delete] wp-cli-polylang package

### DIFF
--- a/docker/wp-base/Dockerfile
+++ b/docker/wp-base/Dockerfile
@@ -59,7 +59,6 @@ RUN su -s /bin/sh www-data -c " \
         composer config -g github-oauth.github.com '${GITHUB_API_TOKEN}'; \
     fi;                                                                   \
     wp package install https://github.com/epfl-si/polylang-cli/archive/master.zip ;     \
-    wp package install https://github.com/epfl-si/wp-cli-polylang/archive/master.zip;   \
     wp package install https://github.com/epfl-si/wp-cli/archive/master.zip;            \
     rm -f ~/.composer/auth.json"
 


### PR DESCRIPTION
According to `grep`, the only place in the code base that still uses
this is
https://github.com/epfl-si/jahia2wp/blob/release2018/src/jahia2wp-utils/intlabs_to_prodlabs_backup.sh#L20