### PR TITLE
[feature] `prod_wordpresses` and `test_wordpresses` Ansible groups

### DIFF
--- a/ansible/inventory/wordpress-instances.py
+++ b/ansible/inventory/wordpress-instances.py
@@ -247,9 +247,9 @@ class Inventory:
 
     def _add(self, site):
         self.inventory['_meta']['hostvars'][site.instance_name] = site.hostvars
-        self._add_site_to_group(site, site.wwp_env)
+        self._add_site_to_group(site)
 
-    def _add_site_to_group(self, site, wwp_env):
+    def _add_site_to_group(self, site):
         self._add_group(site.group)
         self.inventory[site.group]['hosts'].append(site.instance_name)
 

--- a/ansible/inventory/wordpress-instances.py
+++ b/ansible/inventory/wordpress-instances.py
@@ -230,7 +230,7 @@ class LiveProductionSite(ProdSiteTrait, _LiveSite):
 
 
 class Inventory:
-    """Model the entire wp-veritas inventory."""
+    """Models the entire inventory."""
 
     def __init__(self, sites):
 

--- a/ansible/inventory/wordpress-instances.py
+++ b/ansible/inventory/wordpress-instances.py
@@ -70,7 +70,13 @@ class _Site:
 
     @property
     def group_hierarchy(self):
-        return ['%s_%s' % (self.group_prefix, re.sub('-', '_', self.wwp_env))]
+        return [
+            '%s_%s' % (self.group_prefix, suffix)
+            for suffix in (
+                re.sub('-', '_', self.wwp_env),
+                'wordpresses'
+                )
+            ]
 
     @property
     def instance_name(self):


### PR DESCRIPTION
`WWP_NAMESPACES=wwp-test,wwp ./ansible/inventory/wordpress-instances.py |diff -U3 inventory.GOLD -`

```
--- inventory.GOLD	2020-08-12 10:23:20.000000000 +0200
+++ -	2020-08-12 10:47:45.000000000 +0200
@@ -19265,15 +19265,8 @@
     },
     "all_wordpresses": {
         "children": [
-            "prod_form",
-            "prod_inside",
-            "prod_labs",
-            "prod_sandbox",
-            "prod_subdomains_lite",
-            "prod_subdomains",
-            "prod_www",
-            "test_dev",
-            "test_int"
+            "prod_wordpresses",
+            "test_wordpresses"
         ]
     },
     "prod_form": {
@@ -20837,6 +20830,17 @@
             "nrg2021"
         ]
     },
+    "prod_wordpresses": {
+        "children": [
+            "prod_form",
+            "prod_inside",
+            "prod_labs",
+            "prod_sandbox",
+            "prod_subdomains_lite",
+            "prod_subdomains",
+            "prod_www"
+        ]
+    },
     "prod_www": {
         "hosts": [
             "www",
@@ -21925,5 +21929,11 @@
             "test_migration_wp__polylex2",
             "test_migration_wp__labs__aaa"
         ]
+    },
+    "test_wordpresses": {
+        "children": [
+            "test_dev",
+            "test_int"
+        ]
     }
 }
```