### PR TITLE
[refactor] Secret passing through environment variables

### DIFF
--- a/ansible/roles/awx-instance/tasks/container-group.yml
+++ b/ansible/roles/awx-instance/tasks/container-group.yml
@@ -70,7 +70,7 @@
             imagePullPolicy: Always
             envFrom:
               - configMapRef:
-                  name: jahia2wp-env
+                  name: new-wp-site-env
               - secretRef:
                   name: mysql-super-credentials
             env:

--- a/ansible/roles/wordpress-instance/filter_plugins/base64.py
+++ b/ansible/roles/wordpress-instance/filter_plugins/base64.py
@@ -1,0 +1,11 @@
+"""Base64 helpers."""
+
+from base64 import b64encode
+
+class FilterModule(object):
+    def filters(self):
+        return {
+            'base64_values': self.base64_values
+        }
+    def base64_values(self, d):
+        return dict((k, b64encode(bytes(v, 'utf-8'))) for k, v in d.items())

--- a/ansible/roles/wordpress-instance/lookup_plugins/env_secrets.py
+++ b/ansible/roles/wordpress-instance/lookup_plugins/env_secrets.py
@@ -1,0 +1,57 @@
+# (c) 2020, EPFL IDEV-FSD <idev-fsd@groupes.epfl.ch>
+
+"""Look up a secret either from the `env_secrets` Ansible variable, or from the environment.
+
+This is mainly intended for Ansible tasks that require wielding secrets, and
+that must also work on AWX / Ansible Tower / the mgmt pod (where Keybase is not
+available, for security reasons). For instance, the following piece of Jinja
+
+    lookup("env_secrets", "mysql_super_credentials", "MYSQL_SUPER_PASSWORD")
+
+is the same as `lookup("env", "MYSQL_SUPER_PASSWORD")` on AWX, and the same as
+`env_secrets.mysql_super_credentials.MYSQL_SUPER_PASSWORD` on the operator's
+workstation.
+
+Usage:
+
+- To produce an env_secrets section: simply add it to ../../../vars/env-secrets.yml
+
+- To convey an env_secrets section into AWX or the mgmt pod: evaluate it (sans
+lookup), make a Kubernetes secret out of it (you may find the `base64_values`
+Jinja filter useful for this sub-task), and expose it to the pod as a set of
+environment variables.
+
+- To consume an env_secrets section in a portable manner: see above.
+
+"""
+
+from ansible.errors import AnsibleError
+from ansible.plugins.lookup import LookupBase
+
+import os
+
+def cached(fn):
+    cache_key = '__cached_' + fn.__name__
+    def uncached(self_or_cls):
+        if not hasattr(self_or_cls, cache_key):
+            setattr(self_or_cls, cache_key, fn(self_or_cls))
+        return getattr(self_or_cls, cache_key)
+    return uncached
+
+
+class LookupModule(LookupBase):
+    @classmethod
+    @cached
+    def _has_secrets(cls):
+        return os.path.exists("/keybase")
+
+    def run(self, terms, variables, **kwargs):
+        if len(terms) != 2:
+            raise AnsibleError('Usage: lookup("env_secrets", SECTION, KEY)')
+        [section, key] = terms
+
+        if self._has_secrets():
+            self._templar.available_variables = variables
+            return [self._templar.template(variables["env_secrets"])[section][key]]
+        else:
+            return [os.getenv(key)]

--- a/ansible/roles/wordpress-instance/tasks/create.yml
+++ b/ansible/roles/wordpress-instance/tasks/create.yml
@@ -1,7 +1,7 @@
 # Create a WordPress site out of thin air
 - include_vars: ../../../vars/wordpress-vars.yml          # For wp_version_lineage
 - include_vars: ../../../vars/env-secrets.yml             # For lookup("env_secrets", ...)
-- include_vars: "../../wordpress-openshift-namespace/vars/secrets-{{ openshift_namespace }}.yml"
+- include_vars: "../../../vars/secrets-{{ openshift_namespace }}.yml"
 
 - name: Create site directory
   file:

--- a/ansible/roles/wordpress-instance/tasks/create.yml
+++ b/ansible/roles/wordpress-instance/tasks/create.yml
@@ -1,4 +1,7 @@
 # Create a WordPress site out of thin air
+- include_vars: ../../../vars/wordpress-vars.yml          # For wp_version_lineage
+- include_vars: ../../../vars/env-secrets.yml             # For lookup("env_secrets", ...)
+- include_vars: "../../wordpress-openshift-namespace/vars/secrets-{{ openshift_namespace }}.yml"
 
 - name: Create site directory
   file:
@@ -15,7 +18,12 @@
     cmd: |
       if wp --path="{{ wp_dir }}" eval '1;'; then echo SITE_ALREADY_EXISTS; exit 0; fi
 
-      . /etc/profile.d/k8s-env.sh
+      export WORDPRESS_VERSION='{{ wp_version_lineage }}'
+      export MYSQL_DB_HOST='{{ mysql_super_credentials.host }}'
+      export MYSQL_SUPER_USER='{{ mysql_super_credentials.user }}'
+      export WP_ADMIN_USER=admin
+      export WP_ADMIN_EMAIL=test@example.com
+      export MYSQL_SUPER_PASSWORD='{{ lookup("env_secrets", "mysql_super_credentials", "MYSQL_SUPER_PASSWORD") }}'
       new-wp-site
   register: _new_wp_site
   changed_when: >-

--- a/ansible/roles/wordpress-openshift-namespace/tasks/images.yml
+++ b/ansible/roles/wordpress-openshift-namespace/tasks/images.yml
@@ -7,7 +7,7 @@
 
 - include_vars: ../../../vars/image-vars.yml
 
-- include_vars: secrets-wwp-test.yml
+- include_vars: ../../../vars/secrets-wwp-test.yml
   when: openshift_namespace == 'wwp-test'
 
 - name: "Testing ImageStreams and their build information"

--- a/ansible/roles/wordpress-openshift-namespace/tasks/mgmt.yml
+++ b/ansible/roles/wordpress-openshift-namespace/tasks/mgmt.yml
@@ -27,7 +27,7 @@
     data:
       WP_ADMIN_USER: admin
       WP_ADMIN_EMAIL: test@example.com
-      WP_VERSION: "{{ wp_version_lineage }}"
+      WP_VERSION: "{{ wp_version_lineage | string }}"
 
 - name: mysql-super-credentials Secret
   openshift:

--- a/ansible/roles/wordpress-openshift-namespace/tasks/mgmt.yml
+++ b/ansible/roles/wordpress-openshift-namespace/tasks/mgmt.yml
@@ -28,6 +28,8 @@
     data:
       WP_ADMIN_USER: admin
       WP_ADMIN_EMAIL: test@example.com
+      MYSQL_DB_HOST: "{{ mysql_super_credentials.host }}"
+      MYSQL_SUPER_USER: "{{ mysql_super_credentials.user }}"
       WP_VERSION: "{{ wp_version_lineage | string }}"
 
 - name: mysql-super-credentials Secret

--- a/ansible/roles/wordpress-openshift-namespace/tasks/mgmt.yml
+++ b/ansible/roles/wordpress-openshift-namespace/tasks/mgmt.yml
@@ -17,13 +17,13 @@
         app: mgmt
     data: "{{ mgmt_ssh_secret_contents }}"
 
-- name: jahia2wp-env ConfigMap
+- name: new-wp-site-env ConfigMap
   openshift:
     state: latest
     apiVersion: v1
     kind: ConfigMap
     metadata:
-      name: jahia2wp-env
+      name: new-wp-site-env
       namespace: "{{ openshift_namespace }}"
     data:
       WP_ADMIN_USER: admin
@@ -79,7 +79,7 @@
               mountPath: /backups
             envFrom:
               - configMapRef:
-                  name: jahia2wp-env
+                  name: new-wp-site-env
               - secretRef:
                   name: mysql-super-credentials
           serviceAccount: "{{ mgmt_service_account }}"

--- a/ansible/roles/wordpress-openshift-namespace/tasks/mgmt.yml
+++ b/ansible/roles/wordpress-openshift-namespace/tasks/mgmt.yml
@@ -4,17 +4,17 @@
 - include_vars: ../../../vars/wordpress-vars.yml          # For wp_version_lineage
 - include_vars: "secrets-{{ openshift_namespace }}.yml"
 
-- name: "{{ mgmt_secret_name }} secret (ssh host and user keys)"
+- name: "{{ mgmt_ssh_secret_name }} secret (ssh host and user keys)"
   openshift:
     state: latest
     apiVersion: v1
     kind: Secret
     metadata:
-      name: "{{ mgmt_secret_name }}"
+      name: "{{ mgmt_ssh_secret_name }}"
       namespace: "{{ openshift_namespace }}"
       labels:
         app: mgmt
-    data: "{{ mgmt_secret_contents }}"
+    data: "{{ mgmt_ssh_secret_contents }}"
 
 - name: jahia2wp-env ConfigMap
   openshift:
@@ -90,7 +90,7 @@
               claimName: wordpress-0
           - name: ssh
             secret:
-              secretName: "{{ mgmt_secret_name }}"
+              secretName: "{{ mgmt_ssh_secret_name }}"
           - >-
             {{ { "name": "backups",
                  "persistentVolumeClaim": {"claimName": "backups-0"} }

--- a/ansible/roles/wordpress-openshift-namespace/tasks/mgmt.yml
+++ b/ansible/roles/wordpress-openshift-namespace/tasks/mgmt.yml
@@ -2,7 +2,7 @@
 - include_vars: ../../../vars/ssh-keys.yml  # Required by mgmt-vars.yml
 - include_vars: ../../../vars/image-vars.yml              # For mgmt_image_name
 - include_vars: ../../../vars/wordpress-vars.yml          # For wp_version_lineage
-- include_vars: "secrets-{{ openshift_namespace }}.yml"
+- include_vars: "../../../vars/secrets-{{ openshift_namespace }}.yml"
 - include_vars: ../../../vars/env-secrets.yml             # For env_secrets
 
 - name: "{{ mgmt_ssh_secret_name }} secret (ssh host and user keys)"

--- a/ansible/roles/wordpress-openshift-namespace/tasks/mgmt.yml
+++ b/ansible/roles/wordpress-openshift-namespace/tasks/mgmt.yml
@@ -3,6 +3,7 @@
 - include_vars: ../../../vars/image-vars.yml              # For mgmt_image_name
 - include_vars: ../../../vars/wordpress-vars.yml          # For wp_version_lineage
 - include_vars: "secrets-{{ openshift_namespace }}.yml"
+- include_vars: ../../../vars/env-secrets.yml             # For env_secrets
 
 - name: "{{ mgmt_ssh_secret_name }} secret (ssh host and user keys)"
   openshift:
@@ -38,10 +39,7 @@
       name: mysql-super-credentials
       namespace: "{{ openshift_namespace }}"
     type: Opaque
-    data:
-      MYSQL_DB_HOST: "{{ mysql_super_credentials.host | b64encode }}"
-      MYSQL_SUPER_USER: "{{ mysql_super_credentials.user | b64encode }}"
-      MYSQL_SUPER_PASSWORD: "{{ mysql_super_credentials.password | eyaml(eyaml_keys) | b64encode }}"
+    data: "{{ env_secrets.mysql_super_credentials | base64_values }}"
 
 - name: mgmt DeploymentConfig
   openshift:

--- a/ansible/roles/wordpress-openshift-namespace/vars/mgmt-vars.yml
+++ b/ansible/roles/wordpress-openshift-namespace/vars/mgmt-vars.yml
@@ -29,9 +29,9 @@ _mgmt_access_list_wwp_test_and_wwp:
 _mgmt_access_list_wwp_test_only:
   - mohamed.khadri@epfl.ch
 
-mgmt_secret_name: mgmt-ssh
+mgmt_ssh_secret_name: mgmt-ssh
 
-mgmt_secret_contents:
+mgmt_ssh_secret_contents:
   # These secrets are consumed by
   # ../../../../docker/mgmt/docker-entrypoint.sh
   authorized_keys: "{{ mgmt_access_list[openshift_namespace] | maplookup(ssh_public_keys) | join_lines | b64encode }}"

--- a/ansible/vars/env-secrets.yml
+++ b/ansible/vars/env-secrets.yml
@@ -1,5 +1,8 @@
+# Secrets that can be looked up using lookup("env_secrets", ...)
+
 env_secrets:
   mysql_super_credentials:
+    # TODO: remove MYSQL_DB_HOST and MYSQL_SUPER_USER (these are not real secrets)
     MYSQL_DB_HOST: "{{ mysql_super_credentials.host }}"
     MYSQL_SUPER_USER: "{{ mysql_super_credentials.user }}"
     MYSQL_SUPER_PASSWORD: "{{ mysql_super_credentials.password | eyaml(eyaml_keys) }}"

--- a/ansible/vars/env-secrets.yml
+++ b/ansible/vars/env-secrets.yml
@@ -2,7 +2,4 @@
 
 env_secrets:
   mysql_super_credentials:
-    # TODO: remove MYSQL_DB_HOST and MYSQL_SUPER_USER (these are not real secrets)
-    MYSQL_DB_HOST: "{{ mysql_super_credentials.host }}"
-    MYSQL_SUPER_USER: "{{ mysql_super_credentials.user }}"
     MYSQL_SUPER_PASSWORD: "{{ mysql_super_credentials.password | eyaml(eyaml_keys) }}"

--- a/ansible/vars/env-secrets.yml
+++ b/ansible/vars/env-secrets.yml
@@ -1,4 +1,6 @@
 # Secrets that can be looked up using lookup("env_secrets", ...)
+#
+# See explanations in ../roles/wordpress-instance/lookup_plugins/env_secrets.py
 
 env_secrets:
   mysql_super_credentials:

--- a/ansible/vars/env-secrets.yml
+++ b/ansible/vars/env-secrets.yml
@@ -1,0 +1,5 @@
+env_secrets:
+  mysql_super_credentials:
+    MYSQL_DB_HOST: "{{ mysql_super_credentials.host }}"
+    MYSQL_SUPER_USER: "{{ mysql_super_credentials.user }}"
+    MYSQL_SUPER_PASSWORD: "{{ mysql_super_credentials.password | eyaml(eyaml_keys) }}"

--- a/ansible/vars/secrets-wwp-test.yml
+++ b/ansible/vars/secrets-wwp-test.yml
@@ -5,7 +5,7 @@
 #
 #   eyaml edit -d \
 #     --pkcs7-public-key ansible/eyaml/epfl_wp_test.pem \
-#     ansible/roles/wordpress-openshift-namespace/vars/secrets-wwp-test.yml
+#     ansible/vars/secrets-wwp-test.yml
 #
 # 💡 This *will not* decrypt anything for you because chances are, you
 # don't need to decrypt secrets (YA RLY). For those cases where you

--- a/ansible/vars/secrets-wwp.yml
+++ b/ansible/vars/secrets-wwp.yml
@@ -5,7 +5,7 @@
 #
 #   eyaml edit -d \
 #     --pkcs7-public-key ansible/eyaml/epfl_wp_prod.pem \
-#     ansible/roles/wordpress-openshift-namespace/vars/secrets-wwp.yml
+#     ansible/vars/secrets-wwp.yml
 #
 # 💡 This *will not* decrypt anything for you because chances are, you
 # don't need to decrypt secrets (YA RLY). For those cases where you


### PR DESCRIPTION
Previously:

- `ansible/roles/wordpress-instances/tasks/create.yml` acquired the secrets by sourcing a file that only exists on the mgmt container

Now:
- Secrets can be looked up using `lookup("env_secrets", SECTION, VARIABLE)`; this will Do The Right Thing both on awx and on “classical” Ansible, running from the operator's workstation
- The dataflow for the corresponding secrets has been refactored and documented (through a Kubernetes Secret, into environment variables that the mgmt and awx-runner pods can consume)

Also:
- The `jahia2wp-env` ConfigMap object has been renamed to `new-wp-site-env`
