### PR TITLE
[feature] Clean up former PDF-related plug-ins

### DIFF
--- a/ansible/roles/wordpress-instance/tasks/main.yml
+++ b/ansible/roles/wordpress-instance/tasks/main.yml
@@ -111,6 +111,7 @@
     - plugins.intranet.htaccess
     - wp.plugins.wpforms
     - wp.plugins.payonline
+    - wp.plugins.pdf
   include_tasks:
     file: "plugins.yml"
     apply:

--- a/ansible/roles/wordpress-instance/tasks/plugins.yml
+++ b/ansible/roles/wordpress-instance/tasks/plugins.yml
@@ -188,6 +188,16 @@
       - symlinked
       - active
     from: wordpress.org/plugins
+  tags: wp.plugins.pdf
+
+- name: Remove obsolete PDF plug-ins (one-shot action)
+  wordpress_plugin:
+    name: "{{ item }}"
+    state: absent
+  with_items:
+    - pdf-viewer-block
+    - pdfjs-viewer-shortcode
+  tags: wp.plugins.pdf
 
 - name: Polylang plugin
   wordpress_plugin:


### PR DESCRIPTION
- Make a `state: absent` one-shot action
- Create tag `wp.plugins.pdf`