### PR TITLE
[feature] Use new wp-veritas test instance

### DIFF
--- a/ansible/inventory/wordpress-instances.py
+++ b/ansible/inventory/wordpress-instances.py
@@ -169,8 +169,8 @@ class WpVeritasSite(ProdSiteTrait, _Site):
 
 
 class WpVeritasTestSite(TestSiteTrait, WpVeritasSite):
-    WP_VERITAS_SITES_API_URL = 'https://wp-veritas.128.178.222.83.nip.io/api/v1/sites'
-    VERIFY_SSL = False
+    WP_VERITAS_SITES_API_URL = 'https://wp-veritas-test.epfl.ch/api/v1/sites'
+    VERIFY_SSL = True
 
 
 class _LiveSite(_Site):

--- a/ansible/roles/wordpress-instance/vars/main.yml
+++ b/ansible/roles/wordpress-instance/vars/main.yml
@@ -42,7 +42,7 @@ wp_ops_rpcclient_ipv4_range: 10.180.21.0/24
 wpveritas_api_url: '{{ _wpveritas_servers[openshift_namespace] }}'
 _wpveritas_servers:
   wwp: https://wp-veritas.epfl.ch/api
-  wwp-test: https://wp-veritas.128.178.222.83.nip.io/api
+  wwp-test: https://wp-veritas-test.epfl.ch/api
 
 eyaml_keys:
   priv: "/keybase/team/epfl_wp_{{ 'prod' if openshift_namespace == 'wwp' else 'test' }}/eyaml-privkey.pem"


### PR DESCRIPTION
Il existe une nouvelle instance de TEST de wp-veritas : https://wp-veritas-test.epfl.ch/
On peut donc l'utiliser à la place de https://wp-veritas.128.178.222.83.nip.io/ qui devient l'instance de DEV