### PR TITLE
[revert] Additional groups per hostname radix

### DIFF
--- a/ansible/inventory/wordpress-instances.py
+++ b/ansible/inventory/wordpress-instances.py
@@ -71,18 +71,11 @@ class _Site:
     @property
     def group_hierarchy(self):
         def to_group_name_fragment(some_text):
-            return re.sub('[.-]', '_', some_text)
-
-        def hostname_to_slug(hostname):
-            matched = re.match('(.*)\.epfl\.ch', hostname)
-            if matched:
-                hostname = matched.group(1)
-            return to_group_name_fragment(hostname)
+            return re.sub('-', '_', some_text)
 
         return [
             '%s_%s' % (self.group_prefix, suffix)
             for suffix in (
-                hostname_to_slug(self.wp_hostname),
                 to_group_name_fragment(self.wwp_env),
                 'wordpresses'
                 )


### PR DESCRIPTION
This reverts commit 25dbfae5d02670ce7b9c402ee58852820224dc2c.

This was causing a group loop, because “inside” is both a WordPress
environment (as in `/srv/inside`) and a hostname (as in
`inside.epfl.ch`)