### PR TITLE
[refactor] Adopt epfl_si.actions

### DIFF
--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -1,2 +1,7 @@
-- src: epfl_si.ansible_module_openshift
-- src: epfl_si.ansible_module_eyaml
+roles:
+- name: epfl_si.ansible_module_openshift
+- name: epfl_si.ansible_module_eyaml
+
+collections:
+- name: epfl_si.actions
+  version: 0.1.0

--- a/ansible/roles/awx-instance/templates/Dockerfile.wp-ansible-runner
+++ b/ansible/roles/awx-instance/templates/Dockerfile.wp-ansible-runner
@@ -22,6 +22,13 @@ RUN mkdir /etc/ansible;                                                         
       echo 'strategy = mitogen_linear')                                         \
     > /etc/ansible/ansible.cfg
 
+RUN pip3 install mitogen==0.2.9
+RUN mkdir /etc/ansible;                                                         \
+    ( echo '[defaults]';                                                        \
+      echo 'strategy_plugins = /usr/local/lib/python3.6/site-packages/ansible_mitogen/plugins/strategy'; \
+      echo 'strategy = mitogen_linear')                                         \
+    > /etc/ansible/ansible.cfg
+
 ARG RUNNER_PATCH_URLS=""
 ARG ANSIBLE_PATCH_URLS=""
 RUN set -e -x; yum -y install patch;                                        \

--- a/ansible/roles/wordpress-instance/action_plugins/wordpress_action_module.py
+++ b/ansible/roles/wordpress-instance/action_plugins/wordpress_action_module.py
@@ -80,21 +80,15 @@ class WordPressActionModule(ActionBase):
         """
         return '{}/wp-content/{}s/{}'.format(prefix, self._get_type(), basename)
 
-    def _query_wp_cli (self, args, fast=False):
+    def _query_wp_cli (self, args):
         """
         Run WP-CLI to query state.
 
         If you want to change the WordPress state, use _run_wp_cli_change() instead.
 
         :param args: WP-CLI command to execute
-        :param fast: Whether to pass `--skip-packages --skip-themes --skip-plugins` on the
-                     command line
         """
-        cmd = '{} {} {}'.format(
-            self._get_ansible_var("wp_cli_command"),
-            ("--skip-packages --skip-themes --skip-plugins" if fast else ""),
-            args)
-        return self._subaction.query("command", dict(_raw_params=cmd))
+        return self._subaction.query("command", dict(_raw_params=self._make_wp_cli_command(args)))
 
     def _run_wp_cli_change (self, args, pipe_input=None):
         """
@@ -109,8 +103,8 @@ class WordPressActionModule(ActionBase):
                                                       stdin=pipe_input),
                                       update_result=self.result)
 
-    def _get_wp_json (self, suffix, skip_loading_wp=False):
-        return json.loads(self._query_wp_cli(suffix, fast=skip_loading_wp)['stdout'])
+    def _get_wp_json (self, suffix):
+        return json.loads(self._query_wp_cli(suffix)['stdout'])
 
     def _make_wp_cli_command(self, args):
         return '{} {}'.format(

--- a/ansible/roles/wordpress-instance/action_plugins/wordpress_action_module.py
+++ b/ansible/roles/wordpress-instance/action_plugins/wordpress_action_module.py
@@ -29,13 +29,15 @@ class WordPressActionModule(ActionBase):
 
         :param basename: given plugin file/folder for which we have to create a symlink
         """
-        return self._run_action('file', {
+        result = self._run_action('file', {
             'state': 'link',
             # Beware src / path inversion, as is customary with everything symlink:
             'src': self._get_symlink_target(basename),
             'path': self._get_symlink_path(basename),
             },
-            update_result=True)
+            update_result=False)
+        self._update_result(result)
+        return self.result
 
 
     def _do_rimraf_file (self, basename):
@@ -44,10 +46,11 @@ class WordPressActionModule(ActionBase):
 
         :param basename: given plugin file/folder
         """
-        self._run_action('file',
-                         {'state': 'absent',
-                          'path': self._get_symlink_path(basename)},
-                          update_result=True)
+        self._update_result(self._run_action(
+            'file',
+            {'state': 'absent',
+             'path': self._get_symlink_path(basename)},
+            update_result=False))
         return self.result
 
 
@@ -401,8 +404,10 @@ class WordPressPluginOrThemeActionModule(WordPressActionModule):
         """
         Uses WP-CLI to activate plugin
         """
-        return self._run_wp_cli_action('{} activate {}'.format(self._get_type(), self._get_name()),
-                                       update_result=True)
+        self._update_result(self._run_wp_cli_action(
+            '{} activate {}'.format(self._get_type(), self._get_name()),
+            update_result=False))
+        return self.result
 
 
     def _activation_state(self, desired_state):

--- a/ansible/roles/wordpress-instance/action_plugins/wordpress_action_module.py
+++ b/ansible/roles/wordpress-instance/action_plugins/wordpress_action_module.py
@@ -18,7 +18,6 @@ class WordPressActionModule(ActionBase):
         # It will be initialized in child classes
         self.result = None
 
-        self._tmp = tmp
         self._task_vars = task_vars
 
         return super(WordPressActionModule, self).run(tmp, task_vars)
@@ -158,7 +157,7 @@ class WordPressActionModule(ActionBase):
         try:
             # https://www.ansible.com/blog/how-to-extend-ansible-through-plugins at "Action Plugins"
             return self._execute_module(module_name=action_name,
-                                        module_args=args, tmp=self._tmp,
+                                        module_args=args,
                                         task_vars=self._task_vars)
         except AnsibleError as e:
             if not e.message.endswith('was not found in configured module paths'):

--- a/ansible/roles/wordpress-instance/action_plugins/wordpress_action_module.py
+++ b/ansible/roles/wordpress-instance/action_plugins/wordpress_action_module.py
@@ -111,27 +111,6 @@ class WordPressActionModule(ActionBase):
             self._get_ansible_var("wp_cli_command"),
             args)
 
-    def _run_php_code(self, code):
-        """
-        Execute PHP code and returns result
-
-        :param code: Code to execute
-        """
-        result = self._run_shell_action("php -r '{}'".format(code))
-
-        return result['stdout_lines']
-
-
-    def _run_shell_action (self, cmd, also_in_check_mode=False, pipe_input=None):
-        """
-        Executes a Shell command
-
-        :param cmd: Command to execute.
-        """
-        return self._run_action('command', { '_raw_params': cmd, '_uses_shell': True, 'stdin': pipe_input },
-                                also_in_check_mode=also_in_check_mode)
-
-
     def _run_action (self, action_name, args, also_in_check_mode=False):
         """
         Executes an action, using an Ansible module.

--- a/ansible/roles/wordpress-instance/action_plugins/wordpress_action_module.py
+++ b/ansible/roles/wordpress-instance/action_plugins/wordpress_action_module.py
@@ -399,7 +399,8 @@ class WordPressPluginOrThemeActionModule(WordPressActionModule):
         """
         Uses WP-CLI to activate plugin
         """
-        return self._run_wp_cli_action('{} activate {}'.format(self._get_type(), self._get_name()))
+        return self._run_wp_cli_action('{} activate {}'.format(self._get_type(), self._get_name()),
+                                       update_result=True)
 
 
     def _activation_state(self, desired_state):

--- a/ansible/roles/wordpress-instance/action_plugins/wordpress_action_module.py
+++ b/ansible/roles/wordpress-instance/action_plugins/wordpress_action_module.py
@@ -143,28 +143,6 @@ class WordPressActionModule(ActionBase):
         return self._task_vars.get('ansible_check_mode', False)
 
 
-    def _update_result (self, result):
-        """
-        Updates result dict
-
-        :param result: dict to update with
-        """
-        oldresult = deepcopy(self.result)
-        self.result.update(result)
-
-        def _keep_flag_truthy(flag_name):
-            if (flag_name in oldresult and
-                oldresult[flag_name] and
-                flag_name in self.result and
-                not self.result[flag_name]
-            ):
-                self.result[flag_name] = oldresult[flag_name]
-
-        _keep_flag_truthy('changed')
-
-        return self.result
-
-
 class WordPressPluginOrThemeActionModule(WordPressActionModule):
     """Common superclass for the wordpress_plugin and wordpress_theme action modules."""
     # Has to be set in child classes with one of the following value:
@@ -260,12 +238,10 @@ class WordPressPluginOrThemeActionModule(WordPressActionModule):
             self._run_wp_cli_change('plugin install {}'.format(self._task.args.get('from')))
 
         if 'symlinked' in to_undo or 'installed' in to_undo:
-            self._update_result(self._do_rimraf_file(basename))
-            if 'failed' in self.result: return self.result
+            self._do_rimraf_file(basename)
 
         if 'symlinked' in to_do:
-            self._update_result(self._do_symlink_file(basename))
-            if 'failed' in self.result: return self.result
+            self._do_symlink_file(basename)
 
 
     def _ensure_all_files_state (self, desired_state):
@@ -288,7 +264,6 @@ class WordPressPluginOrThemeActionModule(WordPressActionModule):
         # Going through each files/folder for plugin
         for basename in basenames:
             self._ensure_file_state(desired_state, basename)
-            if 'failed' in self.result: return self.result
 
 
     def _get_current_file_state (self, basename):

--- a/ansible/roles/wordpress-instance/action_plugins/wordpress_action_module.py
+++ b/ansible/roles/wordpress-instance/action_plugins/wordpress_action_module.py
@@ -34,7 +34,8 @@ class WordPressActionModule(ActionBase):
             # Beware src / path inversion, as is customary with everything symlink:
             'src': self._get_symlink_target(basename),
             'path': self._get_symlink_path(basename),
-            })
+            },
+            update_result=True)
 
 
     def _do_rimraf_file (self, basename):
@@ -45,7 +46,8 @@ class WordPressActionModule(ActionBase):
         """
         self._run_action('file',
                          {'state': 'absent',
-                          'path': self._get_symlink_path(basename)})
+                          'path': self._get_symlink_path(basename)},
+                          update_result=True)
         return self.result
 
 

--- a/ansible/roles/wordpress-instance/action_plugins/wordpress_action_module.py
+++ b/ansible/roles/wordpress-instance/action_plugins/wordpress_action_module.py
@@ -1,7 +1,3 @@
-
-# There is a name clash with a module in Ansible named "copy":
-deepcopy = __import__('copy').deepcopy
-
 from ansible.plugins.action import ActionBase
 from ansible.errors import AnsibleError, AnsibleActionFail
 from ansible.module_utils import six

--- a/ansible/roles/wordpress-instance/action_plugins/wordpress_action_module.py
+++ b/ansible/roles/wordpress-instance/action_plugins/wordpress_action_module.py
@@ -19,8 +19,8 @@ class WordPressActionModule(ActionBase):
         # It will be initialized in child classes
         self.result = None
 
-        self._task_vars = task_vars  # TODO: remove
-        self._subaction = Subaction(self, self._task_vars)
+        self._task_vars = task_vars  # For the _get_ansible_var() method
+        self._subaction = Subaction(self, task_vars)
 
         return super(WordPressActionModule, self).run(tmp, task_vars)
 

--- a/ansible/roles/wordpress-instance/action_plugins/wordpress_facts.py
+++ b/ansible/roles/wordpress-instance/action_plugins/wordpress_facts.py
@@ -60,6 +60,6 @@ class ActionModule(WordPressActionModule):
         return not (('stat' in stat) and stat['stat'] and 'isdir' in stat['stat'] and (stat['stat']['isdir']))
 
     def _stat (self, relpath):
-        return self._run_action('stat', {
+        return self._subaction.query('stat', {
             'path': os.path.join(self._get_wp_dir(), relpath)
-        }, also_in_check_mode=True)
+        })

--- a/ansible/roles/wordpress-instance/action_plugins/wordpress_facts.py
+++ b/ansible/roles/wordpress-instance/action_plugins/wordpress_facts.py
@@ -61,4 +61,4 @@ class ActionModule(WordPressActionModule):
     def _stat (self, relpath):
         return self._run_action('stat', {
             'path': os.path.join(self._get_wp_dir(), relpath)
-        }, update_result=False, also_in_check_mode=True)
+        }, also_in_check_mode=True)

--- a/ansible/roles/wordpress-instance/action_plugins/wordpress_facts.py
+++ b/ansible/roles/wordpress-instance/action_plugins/wordpress_facts.py
@@ -44,7 +44,8 @@ class ActionModule(WordPressActionModule):
         if wp_is_installed:
             for wat in ['plugin', 'theme']:
                 try:
-                    facts['wp_%s_list' % wat] = self._get_wp_json('%s list --format=json' % wat, skip_loading_wp=True)
+                    facts['wp_%s_list' % wat] = self._get_wp_json(
+                        '%s list --format=json --skip-packages --skip-themes --skip-plugins' % wat)
                 except:
                     pass
 

--- a/ansible/roles/wordpress-instance/action_plugins/wordpress_option.py
+++ b/ansible/roles/wordpress-instance/action_plugins/wordpress_option.py
@@ -51,7 +51,7 @@ class ActionModule(WordPressActionModule):
 
         changed_status_orig = self.result.get('changed')
         cmd = "option update {} {} '{}' --skip-themes --skip-plugins".format(json_format, self._task.args.get('name'), option_value)
-        result = self._run_wp_cli_action(cmd)
+        result = self._run_wp_cli_action(cmd, update_result=True)
         if result.get('failed'):
             return
 

--- a/ansible/roles/wordpress-instance/action_plugins/wordpress_option.py
+++ b/ansible/roles/wordpress-instance/action_plugins/wordpress_option.py
@@ -41,7 +41,7 @@ class ActionModule(WordPressActionModule):
             # Escaping double quotes to avoid problems and unserializing option value and converting it to JSON to reuse it
             # We use PHP do to this because Python doesn't have the appropriate functions for this.. not his job !
             php_cmd = 'echo json_encode(unserialize("{0}"));'.format(option_value.replace('"', '\\"'))
-            option_value = self._run_php_code(php_cmd)
+            option_value = self._php_query(php_cmd)
 
             option_value = option_value[0] if len(option_value) > 0 else ''
 
@@ -58,3 +58,14 @@ class ActionModule(WordPressActionModule):
                 self.result['changed'] = changed_status_orig
             else:
                 del self.result['changed']
+
+    def _php_query(self, code):
+        """
+        Execute some PHP code by forking/exec'ing the `php` command
+
+        :param code: Code to execute
+
+        :return: The list of lines on php's standard output
+        """
+        return self._subaction.query("command",
+                                     dict(_raw_params="php -r '{}'".format(code)))['stdout_lines']

--- a/ansible/roles/wordpress-instance/action_plugins/wordpress_option.py
+++ b/ansible/roles/wordpress-instance/action_plugins/wordpress_option.py
@@ -50,13 +50,10 @@ class ActionModule(WordPressActionModule):
                 json_format = '--format=json'
 
         changed_status_orig = self.result.get('changed')
-        cmd = "option update {} {} '{}' --skip-themes --skip-plugins".format(json_format, self._task.args.get('name'), option_value)
-        result = self._run_wp_cli_action(cmd)
-        self._update_result(result)
-        if result.get('failed'):
-            return
+        self._run_wp_cli_change("option update {} {} '{}' --skip-themes --skip-plugins".format(
+            json_format, self._task.args.get('name'), option_value))
 
-        if 'option is unchanged.' in result['stdout']:
+        if 'option is unchanged.' in self.result['stdout']:
             if changed_status_orig is not None:
                 self.result['changed'] = changed_status_orig
             else:

--- a/ansible/roles/wordpress-instance/action_plugins/wordpress_option.py
+++ b/ansible/roles/wordpress-instance/action_plugins/wordpress_option.py
@@ -51,7 +51,8 @@ class ActionModule(WordPressActionModule):
 
         changed_status_orig = self.result.get('changed')
         cmd = "option update {} {} '{}' --skip-themes --skip-plugins".format(json_format, self._task.args.get('name'), option_value)
-        result = self._run_wp_cli_action(cmd, update_result=True)
+        result = self._run_wp_cli_action(cmd)
+        self._update_result(result)
         if result.get('failed'):
             return
 

--- a/ansible/roles/wordpress-instance/action_plugins/wordpress_option.py
+++ b/ansible/roles/wordpress-instance/action_plugins/wordpress_option.py
@@ -41,7 +41,7 @@ class ActionModule(WordPressActionModule):
             # Escaping double quotes to avoid problems and unserializing option value and converting it to JSON to reuse it
             # We use PHP do to this because Python doesn't have the appropriate functions for this.. not his job !
             php_cmd = 'echo json_encode(unserialize("{0}"));'.format(option_value.replace('"', '\\"'))
-            option_value = self._run_php_code(php_cmd, update_result=False)
+            option_value = self._run_php_code(php_cmd)
 
             option_value = option_value[0] if len(option_value) > 0 else ''
 

--- a/ansible/roles/wordpress-instance/action_plugins/wordpress_plugin.py
+++ b/ansible/roles/wordpress-instance/action_plugins/wordpress_plugin.py
@@ -64,5 +64,6 @@ class ActionModule(WordPressPluginOrThemeActionModule):
         """
         Uses WP-CLI to deactivate plugin
         """
-        return self._run_wp_cli_action('plugin deactivate {}'.format(self._get_name()))
+        return self._run_wp_cli_action('plugin deactivate {}'.format(self._get_name()),
+                                       update_result=True)
 

--- a/ansible/roles/wordpress-instance/action_plugins/wordpress_plugin.py
+++ b/ansible/roles/wordpress-instance/action_plugins/wordpress_plugin.py
@@ -52,8 +52,7 @@ class ActionModule(WordPressPluginOrThemeActionModule):
         """Overridden to try with `wp plugin delete` first."""
         # First try to use wp-cli to uninstall:
         if desired_state == 'absent' and not self._is_check_mode():
-            result = self._run_wp_cli_action('plugin delete {}'.format(self._task.args.get('name')),
-                                             update_result=False)
+            result = self._run_wp_cli_action('plugin delete {}'.format(self._task.args.get('name')))
             if "Plugin already deleted" not in result["stdout"] and "could not be found" not in result["stdout"]:
                 self.result.update(result)
 
@@ -64,8 +63,7 @@ class ActionModule(WordPressPluginOrThemeActionModule):
         """
         Uses WP-CLI to deactivate plugin
         """
-        result = self._run_wp_cli_action('plugin deactivate {}'.format(self._get_name()),
-                                       update_result=False)
+        result = self._run_wp_cli_action('plugin deactivate {}'.format(self._get_name()))
         self._update_result(result)
         return self.result
 

--- a/ansible/roles/wordpress-instance/action_plugins/wordpress_plugin.py
+++ b/ansible/roles/wordpress-instance/action_plugins/wordpress_plugin.py
@@ -30,13 +30,11 @@ class ActionModule(WordPressPluginOrThemeActionModule):
                 bool(desired_activation_state) and
                 'active' in set([current_activation_state]) - set([desired_activation_state])
         ):
-            self._update_result(self._do_deactivate_plugin())
-            if 'failed' in self.result: return self.result
+            self._do_deactivate_plugin()
 
         if desired_installation_state:
             # Setting desired installation state
             self._ensure_all_files_state(desired_installation_state)
-            if 'failed' in self.result: return self.result
 
         if (
                 not self._is_mandatory() and
@@ -44,7 +42,6 @@ class ActionModule(WordPressPluginOrThemeActionModule):
                 'active' in set([desired_activation_state]) - set([current_activation_state])
         ):
             self._do_activate_element()
-            if 'failed' in self.result: return self.result
 
         return self.result
 

--- a/ansible/roles/wordpress-instance/action_plugins/wordpress_plugin.py
+++ b/ansible/roles/wordpress-instance/action_plugins/wordpress_plugin.py
@@ -64,6 +64,9 @@ class ActionModule(WordPressPluginOrThemeActionModule):
         """
         Uses WP-CLI to deactivate plugin
         """
-        return self._run_wp_cli_action('plugin deactivate {}'.format(self._get_name()),
-                                       update_result=True)
+        result = self._run_wp_cli_action('plugin deactivate {}'.format(self._get_name()),
+                                       update_result=False)
+        self._update_result(result)
+        return self.result
+
 

--- a/ansible/roles/wordpress-instance/action_plugins/wordpress_plugin_epfl_intranet.py
+++ b/ansible/roles/wordpress-instance/action_plugins/wordpress_plugin_epfl_intranet.py
@@ -51,8 +51,6 @@ class ActionModule(WordPressActionModule):
 
         result = self._query_wp_cli("epfl intranet status")
 
-        if 'failed' in self.result: return
-
         # Getting parameters
         protection_enabled = self._task.args.get('protection_enabled').strip().lower() == 'yes'
         restrict_to_groups = str(self._task.args.get('restrict_to_groups')).strip()

--- a/ansible/roles/wordpress-instance/action_plugins/wordpress_plugin_epfl_intranet.py
+++ b/ansible/roles/wordpress-instance/action_plugins/wordpress_plugin_epfl_intranet.py
@@ -33,7 +33,7 @@ class ActionModule(WordPressActionModule):
         Tells if the plugin is installed
         """
 
-        result = self._run_wp_cli_action("plugin list --format=csv", update_result=False)
+        result = self._run_wp_cli_action("plugin list --format=csv")
 
         for line in result['stdout_lines'][1:]:
             fields = line.split(',')
@@ -49,7 +49,7 @@ class ActionModule(WordPressActionModule):
         Set correct protection state for plugin
         """
 
-        result = self._run_wp_cli_action("epfl intranet status", update_result=False)
+        result = self._run_wp_cli_action("epfl intranet status")
 
         if 'failed' in self.result: return
 
@@ -67,7 +67,7 @@ class ActionModule(WordPressActionModule):
                 restrict_to_groups_opt = "--restrict-to-groups={}".format(restrict_to_groups) if restrict_to_groups != "" else ""
 
                 wpcli_command = "epfl intranet update-protection {}".format(restrict_to_groups_opt)
-                self._update_result(self._run_wp_cli_action(wpcli_command), update_result=False)
+                self._update_result(self._run_wp_cli_action(wpcli_command))
         
         # Protection needs to be disabled
         else:
@@ -75,4 +75,4 @@ class ActionModule(WordPressActionModule):
             if 'is enabled' in result['stdout']:
                 
                 wpcli_command = "plugin deactivate epfl-intranet"
-                self._update_result(self._run_wp_cli_action(wpcli_command), update_result=False)
+                self._update_result(self._run_wp_cli_action(wpcli_command))

--- a/ansible/roles/wordpress-instance/action_plugins/wordpress_plugin_epfl_intranet.py
+++ b/ansible/roles/wordpress-instance/action_plugins/wordpress_plugin_epfl_intranet.py
@@ -67,7 +67,7 @@ class ActionModule(WordPressActionModule):
                 restrict_to_groups_opt = "--restrict-to-groups={}".format(restrict_to_groups) if restrict_to_groups != "" else ""
 
                 wpcli_command = "epfl intranet update-protection {}".format(restrict_to_groups_opt)
-                self._run_wp_cli_action(wpcli_command)
+                self._run_wp_cli_action(wpcli_command, update_result=True)
         
         # Protection needs to be disabled
         else:
@@ -75,4 +75,4 @@ class ActionModule(WordPressActionModule):
             if 'is enabled' in result['stdout']:
                 
                 wpcli_command = "plugin deactivate epfl-intranet"
-                self._run_wp_cli_action(wpcli_command)
+                self._run_wp_cli_action(wpcli_command, update_result=True)

--- a/ansible/roles/wordpress-instance/action_plugins/wordpress_plugin_epfl_intranet.py
+++ b/ansible/roles/wordpress-instance/action_plugins/wordpress_plugin_epfl_intranet.py
@@ -67,7 +67,6 @@ class ActionModule(WordPressActionModule):
                 restrict_to_groups_opt = "--restrict-to-groups={}".format(restrict_to_groups) if restrict_to_groups != "" else ""
 
                 wpcli_command = "epfl intranet update-protection {}".format(restrict_to_groups_opt)
-                #self._update_result(self._run_wp_cli_action(wpcli_command))
                 self._run_wp_cli_action(wpcli_command)
         
         # Protection needs to be disabled

--- a/ansible/roles/wordpress-instance/action_plugins/wordpress_plugin_epfl_intranet.py
+++ b/ansible/roles/wordpress-instance/action_plugins/wordpress_plugin_epfl_intranet.py
@@ -33,7 +33,7 @@ class ActionModule(WordPressActionModule):
         Tells if the plugin is installed
         """
 
-        result = self._run_wp_cli_action("plugin list --format=csv")
+        result = self._query_wp_cli("plugin list --format=csv")
 
         for line in result['stdout_lines'][1:]:
             fields = line.split(',')
@@ -49,7 +49,7 @@ class ActionModule(WordPressActionModule):
         Set correct protection state for plugin
         """
 
-        result = self._run_wp_cli_action("epfl intranet status")
+        result = self._query_wp_cli("epfl intranet status")
 
         if 'failed' in self.result: return
 
@@ -66,13 +66,11 @@ class ActionModule(WordPressActionModule):
                 # Creating restriction option
                 restrict_to_groups_opt = "--restrict-to-groups={}".format(restrict_to_groups) if restrict_to_groups != "" else ""
 
-                wpcli_command = "epfl intranet update-protection {}".format(restrict_to_groups_opt)
-                self._update_result(self._run_wp_cli_action(wpcli_command))
+                self._run_wp_cli_change("epfl intranet update-protection {}".format(restrict_to_groups_opt))
         
         # Protection needs to be disabled
         else:
             
             if 'is enabled' in result['stdout']:
                 
-                wpcli_command = "plugin deactivate epfl-intranet"
-                self._update_result(self._run_wp_cli_action(wpcli_command))
+                self._run_wp_cli_change("plugin deactivate epfl-intranet")

--- a/ansible/roles/wordpress-instance/action_plugins/wordpress_plugin_epfl_intranet.py
+++ b/ansible/roles/wordpress-instance/action_plugins/wordpress_plugin_epfl_intranet.py
@@ -67,7 +67,7 @@ class ActionModule(WordPressActionModule):
                 restrict_to_groups_opt = "--restrict-to-groups={}".format(restrict_to_groups) if restrict_to_groups != "" else ""
 
                 wpcli_command = "epfl intranet update-protection {}".format(restrict_to_groups_opt)
-                self._run_wp_cli_action(wpcli_command, update_result=True)
+                self._update_result(self._run_wp_cli_action(wpcli_command), update_result=False)
         
         # Protection needs to be disabled
         else:
@@ -75,4 +75,4 @@ class ActionModule(WordPressActionModule):
             if 'is enabled' in result['stdout']:
                 
                 wpcli_command = "plugin deactivate epfl-intranet"
-                self._run_wp_cli_action(wpcli_command, update_result=True)
+                self._update_result(self._run_wp_cli_action(wpcli_command), update_result=False)

--- a/ansible/roles/wordpress-instance/action_plugins/wordpress_polylang_language.py
+++ b/ansible/roles/wordpress-instance/action_plugins/wordpress_polylang_language.py
@@ -44,13 +44,14 @@ class ActionModule(WordPressActionModule):
 
     def _ensure_language_exists(self, language):
         cmd = "pll lang create {name} {slug} {locale} --flag={flag}".format(**self.locales[language])
-        self._run_wp_cli_action(cmd, update_result=True)
+        self._update_result(self._run_wp_cli_action(cmd, update_result=False))
         if language not in self._get_polylang_languages() and language != "en":
             raise AnsibleError("FATAL: {} did not have the expected effect of creating the language - Perhaps the metadata (e.g. the flag) is wrong in wordpress_polylang_language.py?".format(cmd))
 
     def _ensure_language_deleted(self, language):
-        self._run_wp_cli_action("pll lang delete {}".format(language),
-                                update_result=True)
+        self._update_result(self._run_wp_cli_action(
+            "pll lang delete {}".format(language),
+            update_result=False))
 
     def _get_polylang_languages (self):
         """Returns: A dict of `mo_id`s keyed by language slug."""

--- a/ansible/roles/wordpress-instance/action_plugins/wordpress_polylang_language.py
+++ b/ansible/roles/wordpress-instance/action_plugins/wordpress_polylang_language.py
@@ -44,14 +44,13 @@ class ActionModule(WordPressActionModule):
 
     def _ensure_language_exists(self, language):
         cmd = "pll lang create {name} {slug} {locale} --flag={flag}".format(**self.locales[language])
-        self._update_result(self._run_wp_cli_action(cmd, update_result=False))
+        self._update_result(self._run_wp_cli_action(cmd))
         if language not in self._get_polylang_languages() and language != "en":
             raise AnsibleError("FATAL: {} did not have the expected effect of creating the language - Perhaps the metadata (e.g. the flag) is wrong in wordpress_polylang_language.py?".format(cmd))
 
     def _ensure_language_deleted(self, language):
         self._update_result(self._run_wp_cli_action(
-            "pll lang delete {}".format(language),
-            update_result=False))
+            "pll lang delete {}".format(language)))
 
     def _get_polylang_languages (self):
         """Returns: A dict of `mo_id`s keyed by language slug."""
@@ -67,7 +66,7 @@ class ActionModule(WordPressActionModule):
             # `wp pll option sync taxonomies` generates the mo id of
             # newly-created languages, and may or may not be doing something
             # else... Oh well
-            self._run_wp_cli_action("pll option sync taxonomies", update_result=False)
+            self._run_wp_cli_action("pll option sync taxonomies")
             retval = get_moids_by_slug()
 
             # Failing again is fatal.

--- a/ansible/roles/wordpress-instance/action_plugins/wordpress_polylang_language.py
+++ b/ansible/roles/wordpress-instance/action_plugins/wordpress_polylang_language.py
@@ -44,12 +44,13 @@ class ActionModule(WordPressActionModule):
 
     def _ensure_language_exists(self, language):
         cmd = "pll lang create {name} {slug} {locale} --flag={flag}".format(**self.locales[language])
-        self._run_wp_cli_action(cmd)
+        self._run_wp_cli_action(cmd, update_result=True)
         if language not in self._get_polylang_languages() and language != "en":
             raise AnsibleError("FATAL: {} did not have the expected effect of creating the language - Perhaps the metadata (e.g. the flag) is wrong in wordpress_polylang_language.py?".format(cmd))
 
     def _ensure_language_deleted(self, language):
-        self._run_wp_cli_action("pll lang delete {}".format(language))
+        self._run_wp_cli_action("pll lang delete {}".format(language),
+                                update_result=True)
 
     def _get_polylang_languages (self):
         """Returns: A dict of `mo_id`s keyed by language slug."""

--- a/ansible/roles/wordpress-instance/action_plugins/wordpress_polylang_language.py
+++ b/ansible/roles/wordpress-instance/action_plugins/wordpress_polylang_language.py
@@ -37,20 +37,19 @@ class ActionModule(WordPressActionModule):
         current_languages = [lang['slug'] for lang in self._get_wp_json("pll lang list --format=json")]
 
         if expected_state == 'present' and language not in current_languages:
-            self._ensure_language_exists(language)
+            self._do_create_language(language)
 
         if expected_state == 'absent' and language in current_languages:
-            self._ensure_language_deleted(language)
+            self._do_delete_language(language)
 
-    def _ensure_language_exists(self, language):
-        cmd = "pll lang create {name} {slug} {locale} --flag={flag}".format(**self.locales[language])
-        self._update_result(self._run_wp_cli_action(cmd))
+    def _do_create_language(self, language):
+        self._run_wp_cli_change("pll lang create {name} {slug} {locale} --flag={flag}".format(
+            **self.locales[language]))
         if language not in self._get_polylang_languages() and language != "en":
             raise AnsibleError("FATAL: {} did not have the expected effect of creating the language - Perhaps the metadata (e.g. the flag) is wrong in wordpress_polylang_language.py?".format(cmd))
 
-    def _ensure_language_deleted(self, language):
-        self._update_result(self._run_wp_cli_action(
-            "pll lang delete {}".format(language)))
+    def _do_delete_language(self, language):
+        self._run_wp_cli_change("pll lang delete {}".format(language))
 
     def _get_polylang_languages (self):
         """Returns: A dict of `mo_id`s keyed by language slug."""
@@ -66,7 +65,7 @@ class ActionModule(WordPressActionModule):
             # `wp pll option sync taxonomies` generates the mo id of
             # newly-created languages, and may or may not be doing something
             # else... Oh well
-            self._run_wp_cli_action("pll option sync taxonomies")
+            self._run_wp_cli_change("pll option sync taxonomies")
             retval = get_moids_by_slug()
 
             # Failing again is fatal.

--- a/ansible/roles/wordpress-instance/action_plugins/wordpress_polylang_menu.py
+++ b/ansible/roles/wordpress-instance/action_plugins/wordpress_polylang_menu.py
@@ -44,5 +44,4 @@ class ActionModule(WordPressActionModule):
         Ensure that main menu exists
         """
         if not self._menu_exists(self.MAIN_MENU):
-            self._update_result(self._run_wp_cli_action(
-                "pll menu create {} top".format(self.MAIN_MENU)))
+            self._run_wp_cli_change("pll menu create {} top".format(self.MAIN_MENU))

--- a/ansible/roles/wordpress-instance/action_plugins/wordpress_polylang_menu.py
+++ b/ansible/roles/wordpress-instance/action_plugins/wordpress_polylang_menu.py
@@ -44,5 +44,6 @@ class ActionModule(WordPressActionModule):
         Ensure that main menu exists
         """
         if not self._menu_exists(self.MAIN_MENU):
-            self._run_wp_cli_action("pll menu create {} top".format(self.MAIN_MENU),
-                                    update_result=True)
+            self._update_result(self._run_wp_cli_action(
+                "pll menu create {} top".format(self.MAIN_MENU),
+                update_result=False))

--- a/ansible/roles/wordpress-instance/action_plugins/wordpress_polylang_menu.py
+++ b/ansible/roles/wordpress-instance/action_plugins/wordpress_polylang_menu.py
@@ -45,5 +45,4 @@ class ActionModule(WordPressActionModule):
         """
         if not self._menu_exists(self.MAIN_MENU):
             self._update_result(self._run_wp_cli_action(
-                "pll menu create {} top".format(self.MAIN_MENU),
-                update_result=False))
+                "pll menu create {} top".format(self.MAIN_MENU)))

--- a/ansible/roles/wordpress-instance/action_plugins/wordpress_polylang_menu.py
+++ b/ansible/roles/wordpress-instance/action_plugins/wordpress_polylang_menu.py
@@ -44,4 +44,5 @@ class ActionModule(WordPressActionModule):
         Ensure that main menu exists
         """
         if not self._menu_exists(self.MAIN_MENU):
-            self._run_wp_cli_action("pll menu create {} top".format(self.MAIN_MENU))
+            self._run_wp_cli_action("pll menu create {} top".format(self.MAIN_MENU),
+                                    update_result=True)

--- a/ansible/roles/wordpress-instance/action_plugins/wordpress_theme.py
+++ b/ansible/roles/wordpress-instance/action_plugins/wordpress_theme.py
@@ -25,7 +25,6 @@ class ActionModule(WordPressPluginOrThemeActionModule):
         if desired_installation_state:
             # Setting desired installation state
             self._ensure_all_files_state(desired_installation_state)
-            if 'failed' in self.result: return self.result
 
         if (
                 bool(desired_activation_state) and
@@ -34,6 +33,5 @@ class ActionModule(WordPressPluginOrThemeActionModule):
             
             
             self._do_activate_element()
-            if 'failed' in self.result: return self.result
 
         return self.result

--- a/ansible/roles/wordpress-instance/action_plugins/wordpress_unknown_plugins.py
+++ b/ansible/roles/wordpress-instance/action_plugins/wordpress_unknown_plugins.py
@@ -32,8 +32,7 @@ class ActionModule(WordPressActionModule):
                 task_args = dict(name=name, state=state)
                 task_args['is_mu'] = plugin.get('status') == 'must-use'
                 self._update_result(self._run_action(
-                    'wordpress_plugin', task_args,
-                    update_result=False))
+                    'wordpress_plugin', task_args))
                 self.result['wordpress_unknown_plugins'].append(dict(
                     name=name,
                     is_mu=task_args['is_mu']))

--- a/ansible/roles/wordpress-instance/action_plugins/wordpress_unknown_plugins.py
+++ b/ansible/roles/wordpress-instance/action_plugins/wordpress_unknown_plugins.py
@@ -31,8 +31,9 @@ class ActionModule(WordPressActionModule):
             if name not in self.known_plugins:
                 task_args = dict(name=name, state=state)
                 task_args['is_mu'] = plugin.get('status') == 'must-use'
-                self._run_action('wordpress_plugin', task_args,
-                                 update_result=True)
+                self._update_result(self._run_action(
+                    'wordpress_plugin', task_args,
+                    update_result=False))
                 self.result['wordpress_unknown_plugins'].append(dict(
                     name=name,
                     is_mu=task_args['is_mu']))

--- a/ansible/roles/wordpress-instance/action_plugins/wordpress_unknown_plugins.py
+++ b/ansible/roles/wordpress-instance/action_plugins/wordpress_unknown_plugins.py
@@ -31,8 +31,8 @@ class ActionModule(WordPressActionModule):
             if name not in self.known_plugins:
                 task_args = dict(name=name, state=state)
                 task_args['is_mu'] = plugin.get('status') == 'must-use'
-                self._update_result(self._run_action(
-                    'wordpress_plugin', task_args))
+                self._subaction.change(
+                    'wordpress_plugin', task_args, update_result=self.result)
                 self.result['wordpress_unknown_plugins'].append(dict(
                     name=name,
                     is_mu=task_args['is_mu']))

--- a/ansible/roles/wordpress-instance/action_plugins/wordpress_unknown_plugins.py
+++ b/ansible/roles/wordpress-instance/action_plugins/wordpress_unknown_plugins.py
@@ -31,7 +31,8 @@ class ActionModule(WordPressActionModule):
             if name not in self.known_plugins:
                 task_args = dict(name=name, state=state)
                 task_args['is_mu'] = plugin.get('status') == 'must-use'
-                self._run_action('wordpress_plugin', task_args)
+                self._run_action('wordpress_plugin', task_args,
+                                 update_result=True)
                 self.result['wordpress_unknown_plugins'].append(dict(
                     name=name,
                     is_mu=task_args['is_mu']))

--- a/ansible/wpsible
+++ b/ansible/wpsible
@@ -48,6 +48,7 @@ platform_check () {
     fi
     export PATH="$PWD/ansible-deps-cache/bin:$PATH"
     export ANSIBLE_ROLES_PATH="$PWD/ansible-deps-cache/roles"
+    export ANSIBLE_COLLECTIONS_PATHS="$PWD/ansible-deps-cache"
 
     oc_check
 }


### PR DESCRIPTION
Simplify `wordpress_action_module.py` and all its subclasses by moving the responsability of interfacing with Ansible into [a re-useable Ansible collection](https://galaxy.ansible.com/epfl_si/actions).

This is a pure-refactoring PR; the behavior is not supposed to change. Verified with
- `./ansible/wpsible -t wp.wipe,wp.restore,wp -l test_migration_wp__labs__dcsl -vv`
- `./ansible/wpsible -t wp.wipe,wp -l test_migration_wp__labs__dcsl -vv` (the latter requires #350 to be applied first)

