### PR TITLE
[optimize] No need for `wpsible` to run `ansible-galaxy` anymore

### DIFF
--- a/ansible/wpsible
+++ b/ansible/wpsible
@@ -103,7 +103,6 @@ set -e
 platform_check
 case "$mode" in
     ansible-playbook)
-        ansible-galaxy install -i -r requirements.yml >/dev/null 2>&1
         ansible-playbook $playbook_flags $(inventories) "${ansible_args[@]}" \
                          -e "wpsible_cwd=$OLDPWD" \
                          .interactive-playbooks/main.yml


### PR DESCRIPTION
[ansible.suitcase](https://github.com/epfl-si/ansible.suitcase) takes care of it these days.