### PR TITLE
[feature] add more information from wp-veritas

### DIFF
--- a/ansible/inventory/wordpress-instances.py
+++ b/ansible/inventory/wordpress-instances.py
@@ -168,6 +168,7 @@ class WpVeritasSite(ProdSiteTrait, _Site):
     def hostvars(self):
         hostvars = _Site.hostvars.fget(self)
         hostvars['wpveritas_url'] = self.url
+        hostvars['wpveritas_site'] = json.dumps(self.__dict__)
         return hostvars
 
 


### PR DESCRIPTION
Le but de cette PR est de pouvoir lancer l'inventaire pour obtenir un fichier json avec un max de données de wp-veritas.
`WWP_INVENTORY_SOURCES=wpveritas WWP_NAMESPACES=wwp-test ./ansible/inventory/wordpress-instances.py`
Ainsi, on peut se servir de ces données pour les charger dans wp-veritas de test