### PR TITLE
[feature] Install the `aws` command in ansible runner and mgmt containers

### DIFF
--- a/ansible/roles/awx-instance/templates/Dockerfile.wp-ansible-runner
+++ b/ansible/roles/awx-instance/templates/Dockerfile.wp-ansible-runner
@@ -1,6 +1,8 @@
 FROM docker-registry.default.svc:5000/{{ ansible_oc_namespace }}/{{ wp_base_image_name }}:latest
 FROM docker-registry.default.svc:5000/{{ ansible_oc_namespace }}/{{ awx_runner_base_image_name }}:latest
 
+RUN yum -y update
+
 RUN yum -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm
 
 RUN yum -y install http://rpms.remirepo.net/enterprise/remi-release-8.rpm

--- a/ansible/roles/awx-instance/templates/Dockerfile.wp-ansible-runner
+++ b/ansible/roles/awx-instance/templates/Dockerfile.wp-ansible-runner
@@ -13,6 +13,8 @@ RUN yum -y install yum-plugin-copr && yum -y copr enable copart/restic
 
 RUN yum -y install php-cli php-mysql python3 restic jq mysql
 
+RUN pip3 install awscli
+
 ARG RUNNER_PATCH_URLS=""
 ARG ANSIBLE_PATCH_URLS=""
 RUN set -e -x; yum -y install patch;                                        \

--- a/docker/mgmt/Dockerfile
+++ b/docker/mgmt/Dockerfile
@@ -1,6 +1,7 @@
 FROM epflsi/os-wp-base
 
 RUN apt-get -qy update && apt-get -qy install --no-install-recommends \
+    awscli \
     bash-completion \
     htop \
     inotify-tools \


### PR DESCRIPTION
This lets one do e.g.

```
aws --endpoint-url=https://s3.epfl.ch s3 ls --recursive s3://svc0041-47680839aba24f7c02f160cd9d58a5e1/backup/wordpresses/
```

... given that the credentials are already available as part of the environment (via `/etc/profile.d/k8s.sh` as far as mgmt is concerned)

<img width="1120" alt="image" src="https://user-images.githubusercontent.com/1629585/96489088-3cf71f00-123f-11eb-82fc-1980e4eb8e06.png">
