### PR TITLE
[fix] Scrape useful metrics for backup sizes

### DIFF
--- a/ansible/roles/wordpress-instance/tasks/backup.yml
+++ b/ansible/roles/wordpress-instance/tasks/backup.yml
@@ -22,7 +22,7 @@
       set -o pipefail
       set -e -x
 
-      echo "restic_start{url=\"{{ wp_base_url | ensure_trailing_slash }}\", wp_env=\"{{ wp_env }}\"} $(date +%s)" \
+      echo "restic_start{url=\"{{ backup_url_label }}\", wp_env=\"{{ wp_env }}\"} $(date +%s)" \
       | curl -X POST -H "Content-Type: text/plain" --data-binary @- \
             http://pushgateway:9091/metrics/job/backup/instance/{{ inventory_hostname }}
 
@@ -68,14 +68,19 @@
       # Collect completion stats to pushgateway
       (
         restic -r {{ backup_restic_repo_sql }} stats --mode restore-size --json latest \
-        | jq -r '. as $initial_data | keys | map(["restic_s3_sql_" + . + "{url=\"{{ wp_base_url | ensure_trailing_slash }}\", wp_env=\"{{ wp_env }}\"}", $initial_data[.]]) | .[] | @tsv'        
+        | jq -r '. as $initial_data | keys | map(["restic_s3_sql_" + . + "{url=\"{{ backup_url_label }}\", wp_env=\"{{ wp_env }}\"}", $initial_data[.]]) | .[] | @tsv'        
       ) | curl -X POST -H "Content-Type: text/plain" --data-binary @- \
             http://pushgateway:9091/metrics/job/backup/instance/{{ inventory_hostname }}
 
       (
         restic -r {{ backup_restic_repo_files }} stats --mode restore-size --json latest \
-        | jq -r '. as $initial_data | keys | map(["restic_s3_" + . + "{url=\"{{ wp_base_url | ensure_trailing_slash }}\", wp_env=\"{{ wp_env }}\"}", $initial_data[.]]) | .[] | @tsv'
-        echo "restic_success{url=\"{{ wp_base_url | ensure_trailing_slash }}\", wp_env=\"{{ wp_env }}\"} $(date +%s)"
+        | jq -r '. as $initial_data | keys | map(["restic_s3_" + . + "{url=\"{{ backup_url_label }}\", wp_env=\"{{ wp_env }}\"}", $initial_data[.]]) | .[] | @tsv'
+        echo "restic_success{url=\"{{ backup_url_label }}\", wp_env=\"{{ wp_env }}\"} $(date +%s)"
+
+        echo "s3_backup_files_total_size{url=\"{{ backup_url_label }}\", wp_env=\"{{ wp_env }}\"} $({{ backup_aws_s3api_list_cmd }} --prefix {{ backup_aws_s3_prefix }}/files | {{ backup_aws_s3api_jq_sum_cmd }})"
+        echo "s3_backup_sql_total_size{url=\"{{ backup_url_label }}\", wp_env=\"{{ wp_env }}\"} $({{ backup_aws_s3api_list_cmd }} --prefix {{ backup_aws_s3_prefix }}/sql | {{ backup_aws_s3api_jq_sum_cmd }})"
+        echo "s3_backup_files_total_file_count{url=\"{{ backup_url_label }}\", wp_env=\"{{ wp_env }}\"} $({{ backup_aws_s3api_list_cmd }} --prefix {{ backup_aws_s3_prefix }}/files | {{ backup_aws_s3api_jq_count_cmd }})"
+        echo "s3_backup_sql_total_file_count{url=\"{{ backup_url_label }}\", wp_env=\"{{ wp_env }}\"} $({{ backup_aws_s3api_list_cmd }} --prefix {{ backup_aws_s3_prefix }}/sql | {{ backup_aws_s3api_jq_count_cmd }})"
       ) | curl -X POST -H "Content-Type: text/plain" --data-binary @- \
             http://pushgateway:9091/metrics/job/backup/instance/{{ inventory_hostname }}
 

--- a/ansible/roles/wordpress-instance/tasks/backup.yml
+++ b/ansible/roles/wordpress-instance/tasks/backup.yml
@@ -67,10 +67,17 @@
 
       # Collect completion stats to pushgateway
       (
-        restic -r {{ backup_restic_repo_files }} stats --json \
+        restic -r {{ backup_restic_repo_sql }} stats --mode restore-size --json latest \
+        | jq -r '. as $initial_data | keys | map(["restic_s3_sql_" + . + "{url=\"{{ wp_base_url | ensure_trailing_slash }}\", wp_env=\"{{ wp_env }}\"}", $initial_data[.]]) | .[] | @tsv'        
+      ) | curl -X POST -H "Content-Type: text/plain" --data-binary @- \
+            http://pushgateway:9091/metrics/job/backup/instance/{{ inventory_hostname }}
+
+      (
+        restic -r {{ backup_restic_repo_files }} stats --mode restore-size --json latest \
         | jq -r '. as $initial_data | keys | map(["restic_s3_" + . + "{url=\"{{ wp_base_url | ensure_trailing_slash }}\", wp_env=\"{{ wp_env }}\"}", $initial_data[.]]) | .[] | @tsv'
         echo "restic_success{url=\"{{ wp_base_url | ensure_trailing_slash }}\", wp_env=\"{{ wp_env }}\"} $(date +%s)"
       ) | curl -X POST -H "Content-Type: text/plain" --data-binary @- \
             http://pushgateway:9091/metrics/job/backup/instance/{{ inventory_hostname }}
+
   changed_when: true
   ignore_errors: "{{ wp_ignore_backup_errors | default(false) }}"

--- a/ansible/roles/wordpress-instance/vars/backup-vars.yml
+++ b/ansible/roles/wordpress-instance/vars/backup-vars.yml
@@ -1,5 +1,5 @@
 backup_restic_repo_base: >-
-  s3:{{ s3_backup.endpoint_url }}/{{ s3_backup.bucket_name }}/backup/wordpresses/{{ inventory_hostname }}
+  s3:{{ s3_backup.endpoint_url }}/{{ s3_backup.bucket_name }}/{{ backup_aws_s3_prefix }}
 # restic's tagging system is just bananas. Segregate the two backup streams entirely
 backup_restic_repo_files: "{{ backup_restic_repo_base }}/files"
 backup_restic_repo_sql:   "{{ backup_restic_repo_base }}/sql"
@@ -8,3 +8,12 @@ backup_restic_environment:
   AWS_ACCESS_KEY_ID:     '{{ lookup("env_secrets", "restic_backup_credentials", "AWS_ACCESS_KEY_ID") }}'
   AWS_SECRET_ACCESS_KEY: '{{ lookup("env_secrets", "restic_backup_credentials", "AWS_SECRET_ACCESS_KEY") }}'
   RESTIC_PASSWORD:       '{{ lookup("env_secrets", "restic_backup_credentials", "RESTIC_PASSWORD") }}'
+
+backup_aws_s3api_list_cmd: "aws --endpoint-url=https://s3.epfl.ch s3api list-objects --bucket {{s3_backup.bucket_name}}"
+backup_aws_s3_prefix: "backup/wordpresses/{{ inventory_hostname }}"
+backup_aws_s3api_jq_sum_cmd: >-
+  jq '.Contents | map(.Size) | add'
+backup_aws_s3api_jq_count_cmd: >-
+  jq '.Contents | length'
+
+backup_url_label: "{{ wp_base_url | ensure_trailing_slash }}"


### PR DESCRIPTION
- Change `restic_s3_total_size` and `restic_s3_total_file_count` to be the size and file count of the snapshot tagged `latest` (as opposed to some useless theoretical aggregate sum of the sizes of all backups)
- Post new metrics to pushgateway: `restic_s3_sql_total_size`, `restic_s3_sql_total_file_count`, `s3_backup_files_total_size`, `s3_backup_sql_total_size`, `s3_backup_files_total_file_count` and `s3_backup_sql_total_file_count`