### PR TITLE
[fix] Account for files (not just directories)

### DIFF
--- a/docker/disk-usage-statistics/index.ts
+++ b/docker/disk-usage-statistics/index.ts
@@ -31,6 +31,8 @@ if (!lecommander.pushgatewayBaseUrl) {
 console.log(` - pushgateway-base-url: ${lecommander.pushgatewayBaseUrl}`)
 // -- End Args -----------------------------------------------------------------
 
+const BLOCKSIZE = 512
+
 function parseQdirstat(path: string) {
   return from(lines(path)).pipe(
     flatMap((x) => {
@@ -105,7 +107,7 @@ function parseLine(line: string): Record | undefined {
   let matches = regexp.exec(line)
   if (matches) {
     const kind = matches[1],
-      size = Number(matches[3]),
+      size = Math.ceil(Number(matches[3]) / BLOCKSIZE) * BLOCKSIZE,
       time = Number(matches[4])
     if (kind === 'D') {
       return {

--- a/docker/disk-usage-statistics/index.ts
+++ b/docker/disk-usage-statistics/index.ts
@@ -81,7 +81,7 @@ class Site {
   }
 
   private has(path: string) {
-    return path.startsWith(this.veritasPath)
+    return path.replace(/(?<!\/)$/, '/').startsWith(this.veritasPath)
   }
 
   /**

--- a/docker/disk-usage-statistics/index.ts
+++ b/docker/disk-usage-statistics/index.ts
@@ -7,9 +7,9 @@ import lines from 'lines-async-iterator'
 import { UnaryFunction } from 'ix/interfaces'
 import { AsyncIterableX, from } from 'ix/asynciterable'
 import { map, flatMap } from 'ix/asynciterable/operators'
+import lecommander from 'commander'
 
 // -- Args ---------------------------------------------------------------------
-const lecommander = require('commander')
 lecommander.version(require('./package.json').version)
 lecommander
   .name('npm start -- ')

--- a/docker/disk-usage-statistics/index.ts
+++ b/docker/disk-usage-statistics/index.ts
@@ -128,7 +128,7 @@ function parseLine(line: string): Record | undefined {
 let pathPrefix: string
 const qualifyFiles: UnaryFunction<AsyncIterable<Record>, AsyncIterableX<Record>> = map((record) => {
   if (record.kind === 'D') {
-    pathPrefix = record.path
+    pathPrefix = record.dir
   }
   if (record.kind === 'F') {
     record.dir = pathPrefix


### PR DESCRIPTION
- Fix a typo whence `.path` should have read `.dir`,  which resulted in all files being excluded from tallying
- Other related fixes and improvements