### PR TITLE
[feature] Cache wp-cli queries

### DIFF
--- a/ansible/roles/awx-instance/templates/Dockerfile.wp-ansible-runner
+++ b/ansible/roles/awx-instance/templates/Dockerfile.wp-ansible-runner
@@ -61,3 +61,6 @@ RUN set -e -x; mkdir /tmp/install; \
     ansible-galaxy install -i -r /tmp/install/requirements.yml ; \
     ansible-galaxy collection install -i -r /tmp/install/requirements.yml ; \
     rm /tmp/install/requirements.yml
+
+# Activate cache in wordpress_plugin.py
+ENV WPSIBLE_WPCLI_CACHE_DIR=/tmp/wordpress_plugin-cache

--- a/ansible/roles/wordpress-instance/action_plugins/cache.py
+++ b/ansible/roles/wordpress-instance/action_plugins/cache.py
@@ -1,0 +1,83 @@
+from ansible.module_utils import six
+import collections
+import inspect
+
+class _DecoratorCache(object):
+    def __init__(self_, cache):
+        self_.__cache = cache
+
+    def by(self_, key_f):
+        def decorator(f):
+            def wrapped_f(self, *args, **kwargs):
+                cache_key = self_.__get_key(key_f, self, *args, **kwargs)
+                if not self_.__cache.has(cache_key):
+                    self_.__cache.set(cache_key, f(self, *args, **kwargs))
+                return self_.__cache.get(cache_key)
+
+            wrapped_f.__name__ = f.__name__  # YAGNI?
+            return wrapped_f
+        return decorator
+
+    def invalidate_by_prefix(self_, key_f):
+        def decorator(f):
+            def wrapped_f(self, *args, **kwargs):
+                self_.__cache.invalidate_prefix(self_.__get_key(key_f, self, *args, **kwargs))
+                return f(self, *args, **kwargs)
+
+            wrapped_f.__name__ = f.__name__
+            return wrapped_f
+        return decorator
+
+    @staticmethod
+    def __get_key(key_f, self, *args, **kwargs):
+        if len(inspect.signature(key_f).parameters) > 1:
+            # Either the decorator's lambda parameter only takes self, or it
+            # has to swallow the entire set of arguments to the method. This
+            # is not JavaScript. There are rules.
+            key_raw = key_f(self, *args, **kwargs)
+        else:
+            key_raw = key_f(self)
+
+        def hashable(k):
+            return k if hasattr(k, '__hash__') else json.dumps(k)
+
+        if isinstance(key_raw, tuple):
+            return tuple(hashable(k) for k in key_raw)
+        else:
+            return hashable(key_raw)
+
+
+class _InMemoryPrefixCache(object):
+    def __init__(self):
+        self.__contents = {}
+
+    def has(self, key):
+        return key in self.__contents
+
+    def get(self, key):
+        return self.__contents.get(key)
+
+    def set(self, key, value):
+        self.__contents[key] = value
+
+    def invalidate_prefix(self, key_prefix):
+        for k in list(self.__contents):  # Because Python, to put it bluntly, sucks.
+                                         # https://stackoverflow.com/a/11941855/435004
+            if self.__is_prefix(key_prefix, k):
+                del self.__contents[k]
+
+    @staticmethod
+    def __is_prefix(a, b):
+        if isinstance(a, six.string_types) and isinstance(b, six.string_types):
+            return b.startswith(a)
+        elif isinstance(a, tuple) and isinstance(b, tuple):
+            for i in range(len(a)):
+                if a[i] != b[i]:
+                    return False
+            return True
+        else:
+            return False
+
+
+def InMemoryDecoratorCache():
+    return _DecoratorCache(_InMemoryPrefixCache())

--- a/ansible/roles/wordpress-instance/action_plugins/cache.py
+++ b/ansible/roles/wordpress-instance/action_plugins/cache.py
@@ -91,13 +91,13 @@ class _OnDiskPrefixCache(object):
         return os.path.exists(self._key_path(key))
 
     def get(self, key):
-        with open(self._key_path(key)) as f:
+        with open(self._key_path(key), 'rb') as f:
             return pickle.load(f)
 
     def set(self, key, value):
         key_path = self._key_path(key)
         os.makedirs(os.path.dirname(key_path), exist_ok=True)
-        with open(key_path, 'w') as f:
+        with open(key_path, 'wb') as f:
             pickle.dump(value, f)
 
     def invalidate_prefix(self, key_prefix):

--- a/ansible/roles/wordpress-instance/action_plugins/wordpress_action_module.py
+++ b/ansible/roles/wordpress-instance/action_plugins/wordpress_action_module.py
@@ -122,6 +122,9 @@ class WordPressActionModule(ActionBase):
         else:
             return self._templar.template(unexpanded)
 
+    @property
+    def _inventory_hostname(self):
+        return self._get_ansible_var("inventory_hostname")
 
     def _is_filename (self, from_piece):
         """

--- a/ansible/roles/wordpress-instance/action_plugins/wordpress_plugin.py
+++ b/ansible/roles/wordpress-instance/action_plugins/wordpress_plugin.py
@@ -10,7 +10,6 @@ import json
 # To be able to import wordpress_action_module
 sys.path.append(os.path.dirname(__file__))
 
-from ansible.module_utils import six
 from wordpress_action_module import WordPressPluginOrThemeActionModule
 
 class ActionModule(WordPressPluginOrThemeActionModule):

--- a/ansible/roles/wordpress-instance/meta/main.yml
+++ b/ansible/roles/wordpress-instance/meta/main.yml
@@ -1,0 +1,3 @@
+dependencies:
+  - name: epfl_si.ansible_module_openshift
+  - name: epfl_si.ansible_module_eyaml


### PR DESCRIPTION
This is intended to speed up `-t plugins` which in steady-state situation, keeps executing the very same command (`wp plugin list --format=json --skip-packages --skip-themes --skip-plugins'`) over and over again.

- Decorate `wordpress_plugin`'s `ActionModule` with an abstract cache keyed by `inventory_hostname` and the set of parameters passed to the `_query_wp_cli()` method
- Invalidate the cache per `inventory_hostname` whenever the `_run_wp_cli_change()` method is called
- Provide in-memory and on-disk implementations of the cache (the latter is triggered by an environment variable)
