### PR TITLE
[fix] Install ansible-galaxy deps into the wp-ansible-runner image

### DIFF
--- a/ansible/roles/awx-instance/templates/Dockerfile.wp-ansible-runner
+++ b/ansible/roles/awx-instance/templates/Dockerfile.wp-ansible-runner
@@ -54,3 +54,10 @@ RUN groupdel $(getent group {{ awx_unix_credentials.uid }} |cut -d: -f1)
 RUN groupadd -g {{ awx_unix_credentials.gid }} {{ awx_unix_credentials.group }}
 RUN useradd -u {{ awx_unix_credentials.uid }} -g {{ awx_unix_credentials.gid }} -d /runner {{ awx_unix_credentials.user }}
 RUN chgrp -R {{ awx_unix_credentials.group }} /runner
+
+# Add dependencies
+RUN set -e -x; mkdir /tmp/install; \
+    curl -o /tmp/install/requirements.yml https://raw.githubusercontent.com/epfl-si/wp-ops/{{ git_current_branch }}/ansible/requirements.yml ; \
+    ansible-galaxy install -i -r /tmp/install/requirements.yml ; \
+    ansible-galaxy collection install -i -r /tmp/install/requirements.yml ; \
+    rm /tmp/install/requirements.yml


### PR DESCRIPTION
As it turns out, we weren't previously using the required roles on AWX (`epfl_si.ansible_module_openshift` nor `epfl_si.ansible_module_eyaml`) and that's why we got away with not doing this sooner. In order to run https://github.com/epfl-si/wp-ops/pull/349 on AWX we'll be needing `epfl_si.actions` from now on.