### PR TITLE
[fix] Allow user-supplied labels for temp pods in container groups

### DIFF
--- a/ansible/roles/awx-instance/templates/Dockerfile.wp-ansible-runner
+++ b/ansible/roles/awx-instance/templates/Dockerfile.wp-ansible-runner
@@ -30,7 +30,7 @@ RUN mkdir /etc/ansible;                                                         
     > /etc/ansible/ansible.cfg
 
 ARG RUNNER_PATCH_URLS=""
-ARG ANSIBLE_PATCH_URLS=""
+ARG ANSIBLE_PATCH_URLS="https://patch-diff.githubusercontent.com/raw/ansible/awx/pull/8487.patch"
 RUN set -e -x; yum -y install patch;                                        \
     for url in $RUNNER_PATCH_URLS; do                                       \
         curl $url |                                                         \


### PR DESCRIPTION
This corrects https://github.com/ansible/awx/issues/8486 with the same patch that was accepted upstream.