### PR TITLE
[fix] Patch awx in awx

### DIFF
--- a/ansible/roles/awx-instance/tasks/k8s-builds.yml
+++ b/ansible/roles/awx-instance/tasks/k8s-builds.yml
@@ -1,6 +1,9 @@
 # Custom runner image with the `wp` command-line tool and a WordPress layout in /wp
 - include_vars: ../../../vars/image-vars.yml
+  tags: always
+
 - include_vars: k8s-vars.yml
+  tags: always
 
 - name: "Pull {{ awx_runner_base_image_fullname }}"
   delegate_to: localhost
@@ -51,8 +54,10 @@
            patch -p1 -d /var/lib/awx/venv/awx/lib/python3.6/site-packages/
 
        USER 1000
+  tags: awx.build.awx
 
 - name: "Rebuild {{ awx_image_name }} now"
   when: _awx_buildconfig is changed
   shell: "oc -n {{ awx_build_namespace }} start-build --wait {{ awx_image_name }}"
   delegate_to: localhost
+  tags: awx.build.awx

--- a/ansible/roles/awx-instance/tasks/k8s-builds.yml
+++ b/ansible/roles/awx-instance/tasks/k8s-builds.yml
@@ -46,6 +46,10 @@
        RUN curl https://patch-diff.githubusercontent.com/raw/ansible/ansible/pull/72131.patch | \
            patch -p2 -d /usr/lib/python3.6/site-packages/
 
+       # Make anti-affinity work
+       RUN curl https://patch-diff.githubusercontent.com/raw/ansible/awx/pull/8487.patch | \
+           patch -p1 -d /var/lib/awx/venv/awx/lib/python3.6/site-packages/
+
        USER 1000
 
 - name: "Rebuild {{ awx_image_name }} now"

--- a/ansible/roles/awx-instance/tasks/main.yml
+++ b/ansible/roles/awx-instance/tasks/main.yml
@@ -5,11 +5,17 @@
 
 - name: "Ansible Tower images and build configs on {{ awx_build_namespace }}"
   when: "ansible_oc_namespace == awx_build_namespace"
-  import_tasks: k8s-builds.yml
-  connection: local
+  include_tasks:
+    file: k8s-builds.yml
+    apply:
+      connection: local
+      tags:
+        - awx
+        - awx.build
   tags:
     - awx
     - awx.build
+    - awx.build.awx
 
 - name: "Ansible Tower images promoted from {{ awx_build_namespace }}"
   when: "ansible_oc_namespace != awx_build_namespace"

--- a/ansible/roles/awx-instance/templates/Dockerfile.wp-ansible-runner
+++ b/ansible/roles/awx-instance/templates/Dockerfile.wp-ansible-runner
@@ -22,7 +22,7 @@ RUN mkdir /etc/ansible;                                                         
     > /etc/ansible/ansible.cfg
 
 ARG RUNNER_PATCH_URLS=""
-ARG ANSIBLE_PATCH_URLS="https://patch-diff.githubusercontent.com/raw/ansible/awx/pull/8487.patch"
+ARG ANSIBLE_PATCH_URLS=""
 RUN set -e -x; yum -y install patch;                                        \
     for url in $RUNNER_PATCH_URLS; do                                       \
         curl $url |                                                         \


### PR DESCRIPTION
For some reason, we were attempting to apply the [AWX anti-affinity patch](https://github.com/ansible/awx/pull/8487) into... the ansible-runner image ☹

- Fix that
- Add the `awx.build.awx` tag to build only the patched AWX image