### PR TITLE
[fix] push to wwp-infra pushgateway

### DIFF
--- a/ansible/roles/wordpress-instance/vars/backup-vars.yml
+++ b/ansible/roles/wordpress-instance/vars/backup-vars.yml
@@ -21,7 +21,7 @@ backup_aws_s3api_jq_count_cmd: >-
 backup_url_label: "{{ wp_base_url | ensure_trailing_slash }}"
 backup_curl_to_pushgateway_cmd: >-
   curl -X POST -H "Content-Type: text/plain" --data-binary @-
-  http://pushgateway:9091/metrics/job/backup/instance/{{ inventory_hostname }}
+  http://pushgateway.wwp-infra:9091/metrics/job/backup/instance/{{ inventory_hostname }}
 
 backup_bash_stop_on_any_errors: |
   set -o pipefail

--- a/ansible/roles/wordpress-openshift-namespace/templates/prometheus-config.yml
+++ b/ansible/roles/wordpress-openshift-namespace/templates/prometheus-config.yml
@@ -19,7 +19,7 @@ scrape_configs:
   - job_name: 'pushgateway'
     honor_labels: true  # As per https://github.com/prometheus/pushgateway/blob/master/README.md#about-the-job-and-instance-labels
     static_configs:
-    - targets: ['pushgateway:9091']
+    - targets: ['pushgateway.wwp-infra:9091']
 
   # File-based service discovery of WordPresses
   # (https://prometheus.io/docs/prometheus/latest/configuration/configuration/#file_sd_config)


### PR DESCRIPTION
Depuis le 11 Novembre 2020, on poussait dans la pushgateway de wwp au lieu de la pushgateway de wwp-infra. 