### PR TITLE
[fix] ensure that targets are regenerated every run

### DIFF
--- a/ansible/roles/wordpress-openshift-namespace/templates/prometheus-menu-service-discovery.py
+++ b/ansible/roles/wordpress-openshift-namespace/templates/prometheus-menu-service-discovery.py
@@ -70,8 +70,8 @@ class DynamicConfig:
                     labels=dict(wp_env=wp_env))
                 for wp_env, targets in self.enumerate()])
 
-dc = DynamicConfig()
 while True:
+    dc = DynamicConfig()
     try:
         dc.write_targets()
     except:  # noqa


### PR DESCRIPTION
The caching of the sites list among the loop means that no changes happens without restarting the container, resulting in manual operations. This fixes it and the file `targets.json` used by prometheus will be refreshed every minutes.