### PR TITLE
[fix] Migrate away as many images as possible from Docker Hub

### DIFF
--- a/docker/cleanup-call-logs/Dockerfile
+++ b/docker/cleanup-call-logs/Dockerfile
@@ -1,4 +1,4 @@
-FROM openshift/origin-cli:v3.11
+FROM quay.io/openshift/origin-cli:v3.11
 
 COPY cleanup.sh /
 RUN chmod a+x /cleanup.sh

--- a/docker/disk-usage-statistics/Dockerfile
+++ b/docker/disk-usage-statistics/Dockerfile
@@ -1,5 +1,5 @@
 # https://nodejs.org/de/docs/guides/nodejs-docker-webapp/
-FROM node:14
+FROM public.ecr.aws/bitnami/node:14
 
 WORKDIR /usr/src/app
 

--- a/docker/monitoring-wpprobe/Dockerfile
+++ b/docker/monitoring-wpprobe/Dockerfile
@@ -1,5 +1,5 @@
 # https://nodejs.org/de/docs/guides/nodejs-docker-webapp/
-FROM node:13
+FROM public.ecr.aws/bitnami/node:13
 
 WORKDIR /usr/src/app
 

--- a/docker/wp-base/Dockerfile
+++ b/docker/wp-base/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:focal
+FROM public.ecr.aws/ubuntu/ubuntu:focal
 
 # Version pins are defined here:
 ENV PHP_VERSION=7.4


### PR DESCRIPTION
Docker the company is done blowing through investors money, and they
are circling the drain. To be continued for all hits of `ag "FROM "`,
as the rest of the world realises same.