### PR TITLE
[fix] Docker Hub is dead, part deux

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,6 @@ script:
 # Build wp-base first (because other images depend on it)
 - |
   set -e -x
-  docker pull ubuntu:bionic
 
   wp_base_branch_build_arg=
   mgmt_build_args=


### PR DESCRIPTION
Don't `docker pull ubuntu:bionic` — Besides this being dead code, it
causes the build to fail as per the Docker Hub rate limits