### PR TITLE
[fix] Fix 'wp core install' condition

### DIFF
--- a/docker/mgmt/new-wp-site.sh
+++ b/docker/mgmt/new-wp-site.sh
@@ -48,7 +48,7 @@ SQL_CREATE_USER
 
     contents_of_symlinked_index_php > index.php
 
-    if wp eval '1;' 2>&1 |grep "wp core install"; then
+    if ! $(wp core is-installed); then
         do_wp_core_install
     fi
 


### PR DESCRIPTION
Dans le script new-wp-site, la condition permettant de déterminer si la commande `wp core install` doit être exécutée ou non avait un problème.

Soit un nouveau site à installer, nous souhaitons donc que la commande `wp core install` se lance.

![image](https://user-images.githubusercontent.com/4997224/110596505-ac829200-817f-11eb-8530-ccd60a776fae.png)

La commande ne va donc pas se lancer.

En cherchant les possibilités offertes par wp-cli, je suis tombé la dessus:
https://developer.wordpress.org/cli/commands/core/is-installed/

![image](https://user-images.githubusercontent.com/4997224/110596599-c6bc7000-817f-11eb-898a-469f48f6d8c7.png)

C'est mieux !
