### PR TITLE
[fix] Pushgateway address for the disk-usage job

### DIFF
--- a/ansible/roles/wordpress-instance/vars/backup-vars.yml
+++ b/ansible/roles/wordpress-instance/vars/backup-vars.yml
@@ -21,7 +21,7 @@ backup_aws_s3api_jq_count_cmd: >-
 backup_url_label: "{{ wp_base_url | ensure_trailing_slash }}"
 backup_curl_to_pushgateway_cmd: >-
   curl -X POST -H "Content-Type: text/plain" --data-binary @-
-  http://pushgateway.wwp-infra:9091/metrics/job/backup/instance/{{ inventory_hostname }}
+  http://{{ monitoring_pushgateway_url }}/metrics/job/backup/instance/{{ inventory_hostname }}
 
 backup_bash_stop_on_any_errors: |
   set -o pipefail

--- a/ansible/roles/wordpress-instance/vars/wipe-vars.yml
+++ b/ansible/roles/wordpress-instance/vars/wipe-vars.yml
@@ -25,4 +25,4 @@ wipe_paths:
   - xmlrpc.php
 
 wipe_backup_data_in_pushgateway_cmd: >-
-  curl -X DELETE http://pushgateway.wwp-infra:9091/metrics/job/backup/instance/{{ inventory_hostname }}
+  curl -X DELETE http://{{ monitoring_pushgateway_url }}/metrics/job/backup/instance/{{ inventory_hostname }}

--- a/ansible/roles/wordpress-openshift-namespace/tasks/monitoring.yml
+++ b/ansible/roles/wordpress-openshift-namespace/tasks/monitoring.yml
@@ -291,7 +291,7 @@
                     - -i
                     - /srv/batch/disk-usage-report/qdirstat.NEW
                     - -p
-                    - http://pushgateway:9091
+                    - "http://{{ monitoring_pushgateway_url }}"
                     - --webhook
                   volumeMounts:
                     - name: srv

--- a/ansible/roles/wordpress-openshift-namespace/templates/prometheus-config.yml
+++ b/ansible/roles/wordpress-openshift-namespace/templates/prometheus-config.yml
@@ -19,7 +19,7 @@ scrape_configs:
   - job_name: 'pushgateway'
     honor_labels: true  # As per https://github.com/prometheus/pushgateway/blob/master/README.md#about-the-job-and-instance-labels
     static_configs:
-    - targets: ['pushgateway.wwp-infra:9091']
+    - targets: ['{{ monitoring_pushgateway_url }}']
 
   # File-based service discovery of WordPresses
   # (https://prometheus.io/docs/prometheus/latest/configuration/configuration/#file_sd_config)

--- a/ansible/roles/wordpress-openshift-namespace/vars/monitoring-vars.yml
+++ b/ansible/roles/wordpress-openshift-namespace/vars/monitoring-vars.yml
@@ -4,3 +4,8 @@ monitoring_disk_usage_report_webhook_secret: >-
   {{ webhooks.github.monitoring_disk_usage_report | eyaml(eyaml_keys) }}
 
 prometheus_htpass: "\n{% for cred in prometheus.credentials %}\n          - \"{{ cred.user }}:{{ cred.pass | eyaml(eyaml_keys) | password_hash('bcrypt') }}\"\n{% endfor %}"
+
+monitoring_pushgateway_namespace: >-
+  {{ "wwp-infra" if openshift_namespace == "wwp"
+     else openshift_namespace }}
+monitoring_pushgateway_url: http://pushgateway.{{ monitoring_pushgateway_namespace }}:9091/


### PR DESCRIPTION
The cron job that tallies disk usage is stalling; see e.g. https://pub-os-exopge.epfl.ch/console/project/wwp/browse/pods/srv-disk-usage-report-1609898700-6bj2g?tab=details because it incorrectly tries to phone http://pushgateway:9091/

The pushgateway for things that happen in wwp is reachable at
http://pushgateway.wwp-infra:9091/, whereas the pushgateway for e.g.
the wwp-test namespace is at http://pushgateway.wwp-test:9091/

- Refactor this computation as new variables
`monitoring_pushgateway_namespace` and `monitoring_pushgateway_url`

- Use these variables throughout