### PR TITLE
[feature] Install purchased assets from S3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,3 +35,22 @@ gitbackup: $(_BACKUP_YAMLS)
 	   git commit -m "`echo "$(COMMIT_MSG)\n\nmade with $(MAKE)"`" *.yaml || true;     \
 	   git push);                                                                      \
 	done
+
+S3_ENDPOINT_URL=https://s3.epfl.ch/
+S3_ASSETS_BUCKET=svc0041-c1561ba80625465c2a53f01693922e7c
+
+define source_assets_secrets
+	. /keybase/team/epfl_wp_test/s3-assets-credentials.sh; \
+	export AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY
+endef
+
+.PHONY: assets
+assets:
+	@-mkdir assets 2>/dev/null || true
+	$(source_assets_secrets); \
+	aws --endpoint-url=$(S3_ENDPOINT_URL) s3 sync s3://$(S3_ASSETS_BUCKET) assets/
+
+.PHONY: push-assets
+push-assets:
+	$(source_assets_secrets); \
+	aws --endpoint-url=$(S3_ENDPOINT_URL) s3 sync assets/ s3://$(S3_ASSETS_BUCKET)

--- a/ansible/roles/wordpress-instance/tasks/plugins.yml
+++ b/ansible/roles/wordpress-instance/tasks/plugins.yml
@@ -325,7 +325,7 @@
     state:
       - symlinked
       - active
-    from: https://wp-manager.epfl.ch/resources/plugin-zip/wp-media-folder.zip
+    from: "s3://{{ build.s3_assets.bucket_name }}/wp-media-folder.5.3.18.zip"
 
 - name: wp-media-folder options
   tags:
@@ -459,7 +459,8 @@
   wordpress_plugin:
     name: wpforms
     state: "{{ plugins_for_wpforms_category }}"
-    from: https://wp-manager.epfl.ch/resources/plugin-zip/wpforms.zip
+    from: "s3://{{ build.s3_assets.bucket_name }}/wpforms.1.6.1.2.zip"
+
   tags:
     - wp.plugins.wpforms
 

--- a/ansible/roles/wordpress-openshift-namespace/tasks/images.yml
+++ b/ansible/roles/wordpress-openshift-namespace/tasks/images.yml
@@ -41,6 +41,9 @@
                 --s3-bucket-name={{  build.s3_assets.bucket_name }}
                 --s3-key-id={{       build.s3_assets.key_id }}
                 --s3-secret={{       build.s3_assets.secret | eyaml(eyaml_keys) }}
+                {%if images_build_branch is defined %}
+                --manifest-url=https://raw.githubusercontent.com/epfl-si/wp-ops/{{ images_build_branch }}/ansible/roles/wordpress-instance/tasks/plugins.yml
+                {%endif%}
     - name: "{{ httpd_image_name }}"
       git_path: docker/httpd
       from: "{{ wp_base_image_name }}"

--- a/ansible/roles/wordpress-openshift-namespace/tasks/images.yml
+++ b/ansible/roles/wordpress-openshift-namespace/tasks/images.yml
@@ -7,8 +7,11 @@
 
 - include_vars: ../../../vars/image-vars.yml
 
-- include_vars: ../../../vars/secrets-wwp-test.yml
-  when: openshift_namespace == 'wwp-test'
+- when: openshift_namespace == 'wwp-test'
+  include_vars: "{{ item }}"
+  with_items:
+    - secrets-wwp-test.yml
+    - ../../../vars/secrets-wwp-test.yml
 
 - name: "Testing ImageStreams and their build information"
   when: not openshift_is_production
@@ -32,6 +35,12 @@
               value: "{{ github_api_token.user }}"
             - name: GITHUB_API_TOKEN
               value: "{{ github_api_token.token | eyaml(eyaml_keys) }}"
+            - name: INSTALL_AUTO_FLAGS
+              value: >-
+                --s3-endpoint-url={{ build.s3_assets.endpoint_url }}
+                --s3-bucket-name={{  build.s3_assets.bucket_name }}
+                --s3-key-id={{       build.s3_assets.key_id }}
+                --s3-secret={{       build.s3_assets.secret | eyaml(eyaml_keys) }}
     - name: "{{ httpd_image_name }}"
       git_path: docker/httpd
       from: "{{ wp_base_image_name }}"

--- a/ansible/roles/wordpress-openshift-namespace/vars/secrets-wwp-test.yml
+++ b/ansible/roles/wordpress-openshift-namespace/vars/secrets-wwp-test.yml
@@ -15,3 +15,13 @@
 webhooks:
   github:
     sorryserver: ENC[PKCS7,MIIBeQYJKoZIhvcNAQcDoIIBajCCAWYCAQAxggEhMIIBHQIBADAFMAACAQEwDQYJKoZIhvcNAQEBBQAEggEAfOZC3Lx8xhXXvdkty7fav5nzjwp6cUiags/nW1wRzqb2JuB7uPGWETFaw4O7xGFA+VXnBWPZzfRMdWviibAhNEqNsIU7lbzQBcICqIwG2mqbCk/SigY4X74t582avNFOUhngZ3l1XRwXlZNz1TbKaulLk7SNG2qVHaI+LHJeRrg2gTmz6nDQ5a/bAYMYt2WlxmQpVeGIqRRTE/3F/i7Lq2u0e+Dp2SVI2yRbNzge+CwbZO+63xLKOo0y47ijgsQrVPjQWjtoz6gNhj9rth4jJV58VcXhEkRtVKCAfs1Nd7a85IclRrp16hRxovmt9+LkzVoM4/eo8YeAIFQjuBHxuDA8BgkqhkiG9w0BBwEwHQYJYIZIAWUDBAEqBBDHx0hzK0jnlGtSUASh3ZTjgBAKAldyI0xceu4WHgkp9XK/]
+
+build:
+  s3_assets:
+    endpoint_url: https://s3.epfl.ch/
+    bucket_name: svc0041-c1561ba80625465c2a53f01693922e7c
+    # This is a read-only key. See
+    # the Makefile at the root of wp-ops for write
+    # access
+    key_id: BEK17WIFI2F896UOXHXW
+    secret: ENC[PKCS7,MIIBmQYJKoZIhvcNAQcDoIIBijCCAYYCAQAxggEhMIIBHQIBADAFMAACAQEwDQYJKoZIhvcNAQEBBQAEggEAGJl8T1aQuXckHS6TqQ370RbryFada2GaSljnbwM7NOQIk1BrJRxpADttDcNz6cCq/1H/zfHwTgi5FONhqg1pPlDqprS1M8Z+uBAt6r7sLoNlk1qEqtmVeIkHSvjegl5a/wL2oPxXyxtiR6dkfSP8m/q+hlvO41gA3snNALFkOYTG0VGsZj5I8ZDW3nGsQMZCkyka9dzwaRd4kaT1qIqdeU4R2+esim6QCkRexoc0y3gyW+/u7OH3eemTRarF21FrR3fDZo5wnseVeKc+/3oZOK1SpEfUhsddtIGdR5VQQFJzs4nFHF3+0s6jY0I4yj/sYKCo0AYvJQwiPaK6F5SMojBcBgkqhkiG9w0BBwEwHQYJYIZIAWUDBAEqBBDUezlAMH9BoHd7XAEvg0pvgDA1kx9xRAUpuYGGQv5h6LabqFzRYryerGcSHpnG5qbbEt6HdM+tA0t1OxA3G8SUhtU=]

--- a/ansible/roles/wordpress-openshift-namespace/vars/secrets-wwp.yml
+++ b/ansible/roles/wordpress-openshift-namespace/vars/secrets-wwp.yml
@@ -27,3 +27,8 @@ prometheus:
 webhooks:
   github:
     monitoring_disk_usage_report: ENC[PKCS7,MIIBeQYJKoZIhvcNAQcDoIIBajCCAWYCAQAxggEhMIIBHQIBADAFMAACAQEwDQYJKoZIhvcNAQEBBQAEggEAMq2FoIzulQGmYprID6OZ0OKqylgs4ISJtMk78J8WHvvWqro+79nvP1x/KaNOC1fdFMGeA7sjKkAT7Jjg+t+Q7ELY4LzcjqlYVHhR4+z1KDUbdBDO0pwnpOGIShuBvTUALwfT7xzG8f7L3T2dnN76jShzIRjd5DTOhN3+Fu+MsHD8w7N/Jh0Zfexy6nayO5R8Tspli43nhnffNNc3yNQtSTBch0Jfs6ncbSe6k7+7xqpvxPTpIUxQPihEHci/dXy14mJ7Q7wiC70Sl7WFfzElhtfPsurUSOSoMwaxx2qBW9LogHSh9EcDMYf8GvPVp9D9aQkRtOzk6Tn3P9urfK0dYjA8BgkqhkiG9w0BBwEwHQYJYIZIAWUDBAEqBBAwaCvxefmMpWBwfN0U5/SLgBBRStZQurpiVDcBTVJwx6fK]
+
+# The expansion for this is required but not actually used by Ansible.
+build:
+  s3_assets:
+    bucket_name: svc0041-c1561ba80625465c2a53f01693922e7c

--- a/docker/mgmt/Dockerfile
+++ b/docker/mgmt/Dockerfile
@@ -1,7 +1,6 @@
 FROM epflsi/os-wp-base
 
 RUN apt-get -qy update && apt-get -qy install --no-install-recommends \
-    awscli \
     bash-completion \
     htop \
     inotify-tools \

--- a/docker/wp-base/Dockerfile
+++ b/docker/wp-base/Dockerfile
@@ -7,7 +7,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get -qy update && \
     apt-get -qy install curl ca-certificates \
-               software-properties-common apt-transport-https gnupg && \
+               software-properties-common apt-transport-https gnupg awscli && \
     apt-get -qy autoremove && \
     apt-get clean
 

--- a/docker/wp-base/install-plugins-and-themes.py
+++ b/docker/wp-base/install-plugins-and-themes.py
@@ -35,7 +35,7 @@ Usage:
       --exclude <plugin-name>    Self-explanatory. Used to exclude proprietary
                                  plugins from Travis builds
 
-      --manifest-url             The URL to obtain the plugin manifest from;
+      --manifest-url <url>       The URL to obtain the plugin manifest from;
                                  default is %s
 
   install-plugins-and-themes.py <name> <URL>

--- a/docker/wp-base/install-plugins-and-themes.py
+++ b/docker/wp-base/install-plugins-and-themes.py
@@ -38,6 +38,16 @@ Usage:
       --manifest-url <url>       The URL to obtain the plugin manifest from;
                                  default is %s
 
+      --s3-endpoint-url <url>    The URL of the S3 server that holds the
+                                 purchased assets (plugins or other).
+      --s3-bucket <url>          The bucket name where the purchased assets reside
+      --s3-key-id <s3keyid>
+      --s3-secret <s3secret>     Credentials used to access the assets on S3
+                                 (those whose `from:` start with s3://).
+                                 You can alternatively set environment variables
+                                 AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY (just
+                                 like `aws cp` expects).
+
   install-plugins-and-themes.py <name> <URL>
 
     Install one plugin or theme into the current directory. <name> is
@@ -182,7 +192,7 @@ class Plugin(object):
 
     @staticmethod
     def subclasses():
-        return (ZipPlugin, GitHubPlugin, WordpressOfficialPlugin)
+        return (S3Plugin, ZipPlugin, GitHubPlugin, WordpressOfficialPlugin)
 
     @classmethod
     def _find_handler(cls, url):
@@ -269,6 +279,38 @@ class GitHubPlugin(Plugin):
         for git in self._gits:
             self._copytree_install(git.clone().source_path, target_dir,
                                    rename_dir=self.name if rename_like_self else None)
+
+
+class S3Plugin(Plugin):
+    """A plug-in to obtain from an S3 bucket."""
+
+    @classmethod
+    def handles(cls, url):
+        return url.startswith("s3://")
+
+    client = None
+
+    @classmethod
+    def set_client(cls, client):
+        cls.client = client
+
+    def __init__(self, name, urls):
+        super(S3Plugin, self).__init__(name, urls)
+        assert len(self.urls) == 1
+        self.url = self.urls[0]
+        assert self.handles(self.url)
+
+    def install(self, target_dir, rename_like_self=True):
+        """Unzip into `target_dir`.
+
+        Keyword arguments:
+        rename_like_self -- Ignored - We always unzip to a subdirectory named
+                            `self.name`
+        """
+        tmpzip = "/tmp/%s.zip" % self.name
+        self.client.run_command("cp", self.url, tmpzip)
+        ZipPlugin.install_from_fd(self.name, open(tmpzip, 'rb'), target_dir)
+        os.unlink(tmpzip)
 
 
 class WordpressOfficialPlugin(Plugin):
@@ -366,7 +408,9 @@ class Flags:
         self.auto = argv[0] == 'auto'
         if self.auto:
             try:
-                opts, args = getopt.getopt(argv[1:], "e:v", ["exclude=", "manifest-url="])
+                opts, args = getopt.getopt(argv[1:], "e:v", [
+                    "exclude=", "manifest-url=",
+                    "s3-endpoint-url=", "s3-bucket-name=", "s3-key-id=", "s3-secret="])
             except getopt.GetoptError:
                 usage()
                 sys.exit(1)
@@ -375,9 +419,40 @@ class Flags:
             for o, a in opts:
                 if o == "--manifest-url":
                     self.manifest_url = a
+
+            opts_dict = dict(opts)
+            if "--s3-endpoint-url" in opts_dict:
+                self.s3 = S3(opts_dict["--s3-endpoint-url"],  # Mandatory
+                             opts_dict["--s3-bucket-name"],
+                             # The other two default to the awscli-style
+                             # environment variables:
+                             opts_dict.get("--s3-key-id", None),
+                             opts_dict.get("--s3-secret", None))
+            else:
+                import pprint; pprint.pprint(opts_dict); exit(1)
+                # self.s3 = None
+                pass  # XXX
         else:
             self.name = argv[0]
             self.path = argv[1]
+
+class S3:
+    """Models an S3 bucket client."""
+    def __init__(self, endpoint, bucket_name, keyid, secret):
+        self.endpoint = endpoint
+        self.bucket_name = bucket_name
+        self.keyid = keyid   or os.environ["AWS_ACCESS_KEY_ID"]
+        self.secret = secret or os.environ["AWS_SECRET_ACCESS_KEY"]
+
+    def run_command(self, *args):
+        # Poor man's Jinja:
+        args = [re.sub('\{\{.*\}\}', self.bucket_name, arg)
+                for arg in args]
+        return run_cmd(["aws", "--endpoint-url=%s" % self.endpoint,
+                        "s3", *args],
+                       env=dict(
+                AWS_ACCESS_KEY_ID=self.keyid,
+                AWS_SECRET_ACCESS_KEY=self.secret))
 
 
 WP_INSTALL_DIR = './wp-content'
@@ -390,6 +465,8 @@ if __name__ == '__main__':
     flags = Flags()
 
     if flags.auto:
+        S3Plugin.set_client(flags.s3)
+
         manifest = WpOpsPlugins(flags.manifest_url)
         for d in (WP_PLUGINS_INSTALL_DIR, WP_MU_PLUGINS_INSTALL_DIR):
             if not os.path.isdir(d):

--- a/docker/wp-base/install-plugins-and-themes.py
+++ b/docker/wp-base/install-plugins-and-themes.py
@@ -223,16 +223,21 @@ class ZipPlugin(Plugin):
         rename_like_self -- Ignored - We always unzip to a subdirectory named
                             `self.name`
         """
-        zip = ZipFile(io.BytesIO(requests.get(self.url).content))
-
+        zipfd = io.BytesIO(requests.get(self.url).content)
         progress("Unzipping {}".format(self.url))
+        self.install_from_fd(self.name, zipfd, target_dir)
+
+    @classmethod
+    def install_from_fd(cls, name, fd, target_dir):
+        zip = ZipFile(fd)
+
         for member in zip.namelist():
             zipinfo = zip.getinfo(member)
             if zipinfo.filename[-1] == '/':
                 continue
 
             targetpathelts = os.path.normpath(zipinfo.filename).split('/')
-            targetpathelts[0] = self.name
+            targetpathelts[0] = name
 
             targetpath = os.path.join(target_dir, *targetpathelts)
 


### PR DESCRIPTION
This pull request goes with https://github.com/epfl-si/wp-dev/pull/55

We suffer from occasional build failures because of a BadZipFile error caused by wp-manager.epfl.ch truncating the downloads (for reasons yet unknown). To remediate this, we set up a new bucket on s3.epfl.ch and put our purchased software assets there (for the time being, the list consists of the wp-media-folder and wpforms plugins).

- `install-plugins-and-themes.py` now interpets s3:// URLS in `from: ` lines of plugins.py, provided one passes the `--s3-endpoint-url`, `--s3-bucket`, `--s3-key-id` and `--s3-secret` flags to it
- For repeatable builds (also in the “past” direction), plugins.yml points to a specific release of each purchased asset by name (as opposed to the wp-manager-era practice of using a constant name e.g. `wpforms.zip`)
- In the top-level Makefile, add `make assets` and `make push-assets` to allow the operator to review / edit the files on S3  easily
- Read-write credentials (used only for the aforementioned `make` operations) live in `/keybase/team/epfl_wp_test/s3-assets-credentials.sh` in “raw” form; whereas read-only credentials (used by the build process) are EYAML-encrypted just like the other secrets
- Additionally, introduce optional `images_build_branch` Ansible variable, which lets one do tests in wwp-test such as for instance this very branch: <pre>wpsible -t images -e images_build_branch=feature/install-assets-from-s3</pre>
