### PR TITLE
[feature] `wpsible -t images.promote`

### DIFF
--- a/ansible/roles/wordpress-openshift-namespace/tasks/images.yml
+++ b/ansible/roles/wordpress-openshift-namespace/tasks/images.yml
@@ -6,6 +6,7 @@
 # See also continuous-integration.yml (which has its own set of images)
 
 - include_vars: ../../../vars/image-vars.yml
+  tags: always
 
 - when: openshift_namespace == 'wwp-test'
   include_vars: "{{ item }}"
@@ -63,3 +64,15 @@
   with_items:
     - name: "{{ httpd_image_name }}"
     - name: "{{ mgmt_image_name }}"
+
+- name: "Promote wwp-test images to wwp"
+  when: openshift_is_production
+  tags: images.promote
+  local_action:
+    module: shell
+    cmd: |
+      oc tag wwp-test/mgmt:latest wwp/mgmt:prod
+      oc tag wwp-test/mgmt:latest wwp-infra/mgmt:prod
+      oc tag wwp-test/httpd:latest wwp/httpd:prod
+      oc tag wwp-test/wp-ansible-runner:latest wwp/wp-ansible-runner:latest
+      oc tag wwp-test/cronjob:latest wwp-infra/cronjob:latest

--- a/ansible/roles/wordpress-openshift-namespace/tasks/main.yml
+++ b/ansible/roles/wordpress-openshift-namespace/tasks/main.yml
@@ -2,13 +2,19 @@
 # tasks for WordPress OpenShift namespaces
 
 - name: "Images and builds"
-  import_tasks: images.yml
-  tags: images
+  include_tasks:
+    file: images.yml
+    # Because `include_tasks` is dynamic, tags don't auto-inherit:
+    apply:
+      tags:
+        - images
+  tags:
+    - images
+    - images.promote
 
 - name: "DeploymentConfigs (previously known as pods)"
   include_tasks:
     file: deploymentconfig-httpd.yml
-    # Because `include_tasks` is dynamic, tags don't auto-inherit.
     apply:
       tags: ["dc"]
   loop: "{{ DeploymentConfigs.httpd }}"


### PR DESCRIPTION
This replaces the series of `oc tag` commands that was only available as [old-school documentation](https://confluence.epfl.ch:8443/pages/viewpage.action?pageId=151912818&version=78)