### PR TITLE
[fix] Make `build.s3_assets.bucket_name` a `default` of `roles/wordpress-instance`

### DIFF
--- a/ansible/roles/wordpress-instance/defaults/main/plugin-s3-vars.yml
+++ b/ansible/roles/wordpress-instance/defaults/main/plugin-s3-vars.yml
@@ -1,0 +1,4 @@
+# The expansion for this is required but not actually used by Ansible.
+build:
+  s3_assets:
+    bucket_name: svc0041-c1561ba80625465c2a53f01693922e7c

--- a/ansible/roles/wordpress-openshift-namespace/vars/secrets-wwp.yml
+++ b/ansible/roles/wordpress-openshift-namespace/vars/secrets-wwp.yml
@@ -27,8 +27,3 @@ prometheus:
 webhooks:
   github:
     monitoring_disk_usage_report: ENC[PKCS7,MIIBeQYJKoZIhvcNAQcDoIIBajCCAWYCAQAxggEhMIIBHQIBADAFMAACAQEwDQYJKoZIhvcNAQEBBQAEggEAMq2FoIzulQGmYprID6OZ0OKqylgs4ISJtMk78J8WHvvWqro+79nvP1x/KaNOC1fdFMGeA7sjKkAT7Jjg+t+Q7ELY4LzcjqlYVHhR4+z1KDUbdBDO0pwnpOGIShuBvTUALwfT7xzG8f7L3T2dnN76jShzIRjd5DTOhN3+Fu+MsHD8w7N/Jh0Zfexy6nayO5R8Tspli43nhnffNNc3yNQtSTBch0Jfs6ncbSe6k7+7xqpvxPTpIUxQPihEHci/dXy14mJ7Q7wiC70Sl7WFfzElhtfPsurUSOSoMwaxx2qBW9LogHSh9EcDMYf8GvPVp9D9aQkRtOzk6Tn3P9urfK0dYjA8BgkqhkiG9w0BBwEwHQYJYIZIAWUDBAEqBBAwaCvxefmMpWBwfN0U5/SLgBBRStZQurpiVDcBTVJwx6fK]
-
-# The expansion for this is required but not actually used by Ansible.
-build:
-  s3_assets:
-    bucket_name: svc0041-c1561ba80625465c2a53f01693922e7c


### PR DESCRIPTION
- Cleaner than putting it into secrets-wwp.yml
- Still won't be used anywhere, still required for macro-expansion to work in plugins.yml