### PR TITLE
[Fix] Prometheus execution in WordPress OpenShift platform

### DIFF
--- a/ansible/roles/wordpress-openshift-namespace/tasks/main.yml
+++ b/ansible/roles/wordpress-openshift-namespace/tasks/main.yml
@@ -75,6 +75,7 @@
         - monitoring
   tags:
     - monitoring
+    - monitoring.prometheus
     - monitoring.pushgateway
 
 - name: "Sorry Server"

--- a/ansible/roles/wordpress-openshift-namespace/tasks/monitoring.yml
+++ b/ansible/roles/wordpress-openshift-namespace/tasks/monitoring.yml
@@ -43,6 +43,15 @@
 
 - name: Prometheus StatefulSet
   tags: monitoring.prometheus
+  vars:
+    # https://docs.openshift.com/container-platform/3.11/dev_guide/managing_images.html#image-stream-kubernetes-resources
+    _openshift_image_triggers: >-
+      {{ [dict(from=
+                     dict(kind="ImageStreamTag",
+                          name=monitoring_prober_image_name + ":latest",
+                          namespace="wwp"),
+                   fieldPath='spec.template.spec.containers[?(@.name=="prober")].image'
+                  )] }}
   openshift:
     state: latest
     apiVersion: apps/v1
@@ -51,14 +60,11 @@
       name: prometheus
       namespace: "{{ openshift_namespace }}"
       annotations:
-        # https://docs.openshift.com/container-platform/3.11/dev_guide/managing_images.html#image-stream-kubernetes-resources
+        # Note: *do not* snap definition of _openshift_image_triggers (above)
+        # into place (or if you do, reformat it first). Use git blame to
+        # figure out why.
         image.openshift.io/triggers: >-
-          {{ [dict(from=
-                     dict(kind="ImageStreamTag",
-                          name=monitoring_prober_image_name + ":latest",
-                          namespace="wwp"),
-                   fieldPath='spec.template.spec.containers[?(@.name=="prober")].image'
-                  )] | to_json }}
+          {{ _openshift_image_triggers | to_json }}
 
     spec:
       serviceName: prometheus  # Refs the service above, so that the pods get

--- a/ansible/roles/wordpress-openshift-namespace/tasks/monitoring.yml
+++ b/ansible/roles/wordpress-openshift-namespace/tasks/monitoring.yml
@@ -1,7 +1,11 @@
 - include_vars: monitoring-vars.yml
+  tags: always
+
 - include_vars: secrets-wwp.yml
+  tags: always
 
 - name: Prometheus service
+  tags: monitoring.prometheus
   openshift:
     state: latest
     apiVersion: v1
@@ -19,6 +23,7 @@
         app: prometheus
 
 - name: Prometheus route (https://prometheus-wwp.epfl.ch/)
+  tags: monitoring.prometheus
   openshift:
     state: latest
     apiVersion: route.openshift.io/v1
@@ -37,6 +42,7 @@
         name: prometheus
 
 - name: Prometheus StatefulSet
+  tags: monitoring.prometheus
   openshift:
     state: latest
     apiVersion: apps/v1


### PR DESCRIPTION
- Implement `wpsible -t monitoring.prometheus`
- Fix “Prometheus StatefulSet” task failing because of an Ansible+JSON SNAFU 
