### PR TITLE
[fix] Backup Ansible tasks and variable data flows

### DIFF
--- a/ansible/roles/awx-instance/tasks/main.yml
+++ b/ansible/roles/awx-instance/tasks/main.yml
@@ -94,6 +94,7 @@
             prj.scm_type = "git"
             prj.scm_url = "{{ awx_project_github_url }}"
             prj.scm_branch = "{{ git_current_branch }}"
+            prj.scm_update_on_launch = True
 
 - import_tasks: container-group.yml
   tags: awx

--- a/ansible/roles/wordpress-instance/tasks/backup.yml
+++ b/ansible/roles/wordpress-instance/tasks/backup.yml
@@ -11,6 +11,7 @@
 - include_vars: "{{ item }}"
   with_items:
     - backup-vars.yml
+    - ../../wordpress-openshift-namespace/vars/monitoring-vars.yml
     - ../../../vars/env-secrets.yml                          # Used in backup-vars.yml
     - "../../../vars/secrets-{{ openshift_namespace }}.yml"  # Used in env-secrets.yml
 

--- a/ansible/roles/wordpress-instance/vars/backup-vars.yml
+++ b/ansible/roles/wordpress-instance/vars/backup-vars.yml
@@ -21,7 +21,7 @@ backup_aws_s3api_jq_count_cmd: >-
 backup_url_label: "{{ wp_base_url | ensure_trailing_slash }}"
 backup_curl_to_pushgateway_cmd: >-
   curl -X POST -H "Content-Type: text/plain" --data-binary @-
-  http://{{ monitoring_pushgateway_url }}/metrics/job/backup/instance/{{ inventory_hostname }}
+  {{ monitoring_pushgateway_url }}metrics/job/backup/instance/{{ inventory_hostname }}
 
 backup_bash_stop_on_any_errors: |
   set -o pipefail


### PR DESCRIPTION
- Data flow was broken for the `monitoring_pushgateway_url` variable (missing include_vars + bad computation)
- Despite this, backups were working by mistake since last change around end of June, because they were operating out of an outdated Git clone