### PR TITLE
[fix] Prevent naïve operator from setting a weird branch on AWX

### DIFF
--- a/VARS.md
+++ b/VARS.md
@@ -1,0 +1,9 @@
+# Ansible variables
+
+The variables in the table can be set from the wpsible command line to alter the behavior of the configuration-as-code.
+
+| Variable              | Used in                                   | Explanation                                                                                                                                                            |
+|-----------------------|-------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `awx_playbook_branch` | ansible/roles/awx-instance/tasks/main.yml | Set this to override the branch that Ansible Tower (AWX) shall check out playbooks from (default is `master` in production, and the operator's current branch in test) |
+|                       |                                           |                                                                                                                                                                        |
+|                       |                                           |                                                                                                                                                                        |

--- a/ansible/inventory/prod/group_vars/awx_instances_prod
+++ b/ansible/inventory/prod/group_vars/awx_instances_prod
@@ -1,3 +1,5 @@
+awx_is_production: true
+
 eyaml_keys:
   priv: "/keybase/team/epfl_wp_prod/eyaml-privkey.pem"
   pub: "{{ playbook_dir }}/../eyaml/epfl_wp_prod.pem"

--- a/ansible/inventory/test/group_vars/awx_instances_test
+++ b/ansible/inventory/test/group_vars/awx_instances_test
@@ -1,3 +1,5 @@
+awx_is_production: false
+
 eyaml_keys:
   priv: "/keybase/team/epfl_wp_test/eyaml-privkey.pem"
   pub: "{{ playbook_dir }}/../eyaml/epfl_wp_test.pem"

--- a/ansible/roles/awx-instance/tasks/main.yml
+++ b/ansible/roles/awx-instance/tasks/main.yml
@@ -93,8 +93,13 @@
             prj.organization = org
             prj.scm_type = "git"
             prj.scm_url = "{{ awx_project_github_url }}"
-            prj.scm_branch = "{{ git_current_branch }}"
+            prj.scm_branch = "{{ _awx_playbook_branch }}"
             prj.scm_update_on_launch = True
+  vars:
+    _awx_playbook_branch: >-
+      {{ awx_playbook_branch | default(
+      "master" if awx_is_production else git_current_branch)
+      }}
 
 - import_tasks: container-group.yml
   tags: awx


### PR DESCRIPTION
This prevents the operator from breaking backups when they deploy from a feature branch, and thereafter delete it (e.g. when the feature branch gets merged).

- New inventory variable `awx_is_production`, works like `openshift_is_production`
- If `awx_is_production` is set, then always use the `master` branch, except if overridden by a command-line variable
- Document that variable