### PR TITLE
[fix] Bend over backwards to support jq 1.5

### DIFF
--- a/ansible/roles/wordpress-instance/vars/backup-vars.yml
+++ b/ansible/roles/wordpress-instance/vars/backup-vars.yml
@@ -35,6 +35,6 @@ backup_db_to_stdout_command: >-
   --default-character-set=utf8
   $(
   {{ wp_cli_command }} config list --format=json |
-  jq -r 'from_entries | "\(.DB_NAME) --host=\(.DB_HOST)
+  jq -r 'map(.key = .name | del(.name)) | from_entries | "\(.DB_NAME) --host=\(.DB_HOST)
   --user=\(.DB_USER) --password=\(.DB_PASSWORD)"'
   )


### PR DESCRIPTION
Continued from #443 

Bend over backwards to support jq 1.5 as per
https://stackoverflow.com/questions/51757559/jq-from-entries-function-works-with-key-but-not-name,
and also because the base `ansible-runner` image, itself based on
RedHat something-something, doesn't have jq 1.6

