### PR TITLE
Revert "Fix find my blocks not being available at the moment"

### DIFF
--- a/ansible/roles/wordpress-instance/tasks/plugins.yml
+++ b/ansible/roles/wordpress-instance/tasks/plugins.yml
@@ -378,15 +378,14 @@
   wordpress_option: "{{ item }}"
   with_items: "{{ plugin_enlighter_options }}"
 
-# As it is unavaiable at the moment, this should not be installed
-#- name: "'Find My Blocks' plugin"
-#  wordpress_plugin:
-#    name: find-my-blocks
-#    state:
-#      - symlinked
-#      - active
-#    from: wordpress.org/plugins
-#
+- name: "'Find My Blocks' plugin"
+  wordpress_plugin:
+    name: find-my-blocks
+    state:
+      - symlinked
+      - active
+    from: wordpress.org/plugins
+
 ##################### Category-specific plugins ###########################
 
 - name: epfl-intranet plugin


### PR DESCRIPTION
Reverts epfl-si/wp-ops#447, as it was  a temp fix. Waiting for find-my-blocks to release a new version