### PR TITLE
[fix] wp-ansible-runner: add Perl back

### DIFF
--- a/ansible/roles/awx-instance/tasks/k8s-builds.yml
+++ b/ansible/roles/awx-instance/tasks/k8s-builds.yml
@@ -5,7 +5,7 @@
 - include_vars: k8s-vars.yml
   tags: always
 
-- name: "Pull {{ awx_runner_base_image_fullname }}"
+- name: "Pull {{ awx_runner_base_image_fullname }} into {{ awx_runner_base_image_mirrored_name }}"
   delegate_to: localhost
   openshift_imagestream:
     metadata:

--- a/ansible/roles/awx-instance/tasks/k8s-builds.yml
+++ b/ansible/roles/awx-instance/tasks/k8s-builds.yml
@@ -21,6 +21,7 @@
     metadata:
       name: "{{ awx_runner_image_name }}"
       namespace: "{{ ansible_oc_namespace }}"
+    from: "{{ awx_runner_base_image_mirrored_name }}"
     dockerfile: "{{ lookup('template', 'Dockerfile.' + awx_runner_image_name) }}"
 
 - name: "Rebuild {{ awx_runner_image_name }} now"

--- a/ansible/roles/awx-instance/templates/Dockerfile.wp-ansible-runner
+++ b/ansible/roles/awx-instance/templates/Dockerfile.wp-ansible-runner
@@ -11,7 +11,7 @@ RUN dnf module enable php:remi-7.4 -y
 
 RUN yum -y install yum-plugin-copr && yum -y copr enable copart/restic
 
-RUN yum -y install php-cli php-mysql python3 restic jq mysql pwgen
+RUN yum -y install php-cli php-mysql python3 restic jq mysql pwgen perl
 
 RUN pip3 install awscli
 

--- a/ansible/roles/awx-instance/templates/Dockerfile.wp-ansible-runner
+++ b/ansible/roles/awx-instance/templates/Dockerfile.wp-ansible-runner
@@ -23,13 +23,13 @@ RUN mkdir /etc/ansible;                                                         
 
 ARG RUNNER_PATCH_URLS=""
 ARG ANSIBLE_PATCH_URLS=""
-RUN set -e -x; yum -y install patch;                                        \
+RUN set -o pipefail; set -e -x; yum -y install patch;                       \
     for url in $RUNNER_PATCH_URLS; do                                       \
-        curl $url |                                                         \
+        curl --fail $url |                                                  \
             patch -d /usr/lib/python3.6/site-packages/ansible_runner;       \
     done;                                                                   \
     for url in $ANSIBLE_PATCH_URLS; do                                      \
-        curl $url |                                                         \
+        curl --fail $url |                                                  \
             patch -d /usr/local/lib/python3.6/site-packages/ansible -p3 ;   \
     done;                                                                   \
     yum -y history undo patch
@@ -50,7 +50,7 @@ RUN chgrp -R {{ awx_unix_credentials.group }} /runner
 
 # Add dependencies
 RUN set -e -x; mkdir /tmp/install; \
-    curl -o /tmp/install/requirements.yml https://raw.githubusercontent.com/epfl-si/wp-ops/master/ansible/requirements.yml ; \
+    curl --fail -o /tmp/install/requirements.yml https://raw.githubusercontent.com/epfl-si/wp-ops/master/ansible/requirements.yml ; \
     ansible-galaxy install -i -r /tmp/install/requirements.yml ; \
     ansible-galaxy collection install -i -r /tmp/install/requirements.yml ; \
     rm /tmp/install/requirements.yml

--- a/ansible/roles/awx-instance/vars/k8s-vars.yml
+++ b/ansible/roles/awx-instance/vars/k8s-vars.yml
@@ -11,6 +11,7 @@ awx_web_hostnames:
 awx_runner_base_image_name: ansible-runner
 awx_runner_base_image_fullname: docker.io/ansible/ansible-runner:latest
 awx_runner_image_name: "wp-ansible-runner"
+awx_runner_base_image_mirrored_name: "docker-registry.default.svc:5000/wwp-test/{{ awx_runner_base_image_name }}"
 
 awx_inventory: "{{ awx_inventories[ansible_oc_namespace] }}"
 awx_inventories:


### PR DESCRIPTION
# In this pull request:

Ansible runs on AWX have started failing because the `new-wp-site` requires Perl, which the last build of `wp-ansible-runner` doesn't have. Not exactly sure why we started noticing only this week, but here we are.

- Put Perl back
- Fix some compatibility issues with modern [`ansible-module-openshift`](https://github.com/epfl-si/ansible-module-openshift/) in the configuration-as-code for builds
- Ensure that `curl`ing a 404'd page causes the script to fail cleanly, which would have saved me a bit of a [wild goose chase](https://github.com/epfl-si/ansible-module-openshift/commit/4f3cc06a49755c906e1f6b8116621c3b7db45352) during the root cause analysis of this here PR.
