### PR TITLE
[fix] Use `accred` and `tequila` plugins from https://github.com/epfl-si

### DIFF
--- a/ansible/roles/wordpress-instance/tasks/plugins.yml
+++ b/ansible/roles/wordpress-instance/tasks/plugins.yml
@@ -222,7 +222,7 @@
     state:
       - symlinked
       - active
-    from: https://github.com/epfl-sti/wordpress.plugin.tequila/archive/vpsi.zip
+    from: https://github.com/epfl-si/wordpress.plugin.tequila
 
 - name: Replace WP login screen with redirect-to-Tequila flow
   wordpress_option:
@@ -240,7 +240,7 @@
     state:
       - symlinked
       - active
-    from: https://github.com/epfl-sti/wordpress.plugin.accred/archive/vpsi.zip
+    from: https://github.com/epfl-si/wordpress.plugin.accred
 
 - name: Accred options
   wordpress_option: "{{ item }}"


### PR DESCRIPTION
- Forked https://github.com/epfl-si/wordpress.plugin.tequila from the epfl-sti depot (was already done for the other one)
- Force-pushed `master` branch in both