### PR TITLE
[fix] Move away from Ansible 2.9.6

### DIFF
--- a/ansible/wpsible
+++ b/ansible/wpsible
@@ -44,7 +44,8 @@ platform_check () {
     if ! test -f ansible-deps-cache/.versions 2>/dev/null; then
         curl https://raw.githubusercontent.com/epfl-si/ansible.suitcase/master/install.sh | \
             SUITCASE_DIR=$PWD/ansible-deps-cache SUITCASE_ANSIBLE_REQUIREMENTS=requirements.yml \
-                        SUITCASE_PIP_EXTRA="requests bcrypt passlib mitogen==0.2.9" bash -x
+                        SUITCASE_PIP_EXTRA="requests bcrypt passlib mitogen==0.2.9" \
+                        SUITCASE_ANSIBLE_VERSION=3.4.0 bash -x
     fi
     export PATH="$PWD/ansible-deps-cache/bin:$PATH"
     export ANSIBLE_ROLES_PATH="$PWD/ansible-deps-cache/roles"


### PR DESCRIPTION
https://github.com/ansible/ansible/issues/74725 is fatal to us, since we do need e.g. the `| int` filter to work.

- Use Ansible version 3.4.0