### PR TITLE
[fix] Avoid `ImagePullBackoff`s caused by Docker Hub's rate limit policy

### DIFF
--- a/ansible/roles/awx-instance/tasks/k8s-builds.yml
+++ b/ansible/roles/awx-instance/tasks/k8s-builds.yml
@@ -5,13 +5,13 @@
 - include_vars: k8s-vars.yml
   tags: always
 
-- name: "Pull {{ awx_runner_base_image_fullname }} into {{ awx_runner_base_image_mirrored_name }}"
+- name: "Pull {{ awx_ansible_runner_base_image_mirrored_from }} into {{ awx_ansible_runner_base_image_mirrored_to }}"
   delegate_to: localhost
   openshift_imagestream:
     metadata:
-      name: "{{ awx_runner_base_image_name }}"
+      name: "{{ awx_ansible_runner_base_image_name }}"
       namespace: "{{ ansible_oc_namespace }}"
-    from: "{{ awx_runner_base_image_fullname }}"
+    from: "{{ awx_ansible_runner_base_image_mirrored_from }}"
     tag: latest
 
 - name: "Build {{ awx_runner_image_name }} in OpenShift"
@@ -21,7 +21,7 @@
     metadata:
       name: "{{ awx_runner_image_name }}"
       namespace: "{{ ansible_oc_namespace }}"
-    from: "{{ awx_runner_base_image_mirrored_name }}"
+    from: "{{ awx_ansible_runner_base_image_mirrored_to }}"
     dockerfile: "{{ lookup('template', 'Dockerfile.' + awx_runner_image_name) }}"
 
 - name: "Rebuild {{ awx_runner_image_name }} now"
@@ -29,7 +29,16 @@
   shell: "oc -n {{ awx_build_namespace }} start-build --wait {{ awx_runner_image_name }}"
   delegate_to: localhost
 
-- name: "Patch {{ awx_base_image_full_name }} into {{ awx_image_name }}"
+- name: "Pull upstream awx image into {{ awx_redis_image_mirrored_to }}"
+  delegate_to: localhost
+  openshift_imagestream:
+    metadata:
+      name: awx
+      namespace: "{{ ansible_oc_namespace }}"
+    from: "{{ awx_base_image_mirrored_from }}"
+    tag: "{{ awx_version }}"
+
+- name: "Patch {{ awx_base_image_mirrored_to }} into {{ awx_image_name }}"
   register: _awx_buildconfig
   delegate_to: localhost
   openshift_imagestream:
@@ -38,7 +47,7 @@
       name: "{{ awx_image_name }}"
       namespace: "{{ ansible_oc_namespace }}"
     dockerfile: |
-       FROM {{ awx_base_image_full_name }}
+       FROM {{ awx_base_image_mirrored_to }}
 
        USER 0
        RUN yum -y install patch && yum -y clean all

--- a/ansible/roles/awx-instance/tasks/k8s.yml
+++ b/ansible/roles/awx-instance/tasks/k8s.yml
@@ -100,6 +100,16 @@
       name: "{{ awx_service_account }}"
       namespace: "{{ ansible_oc_namespace }}"
 
+- name: "Pull redis image into {{ awx_redis_image_mirrored_to }}"
+  delegate_to: localhost
+  openshift_imagestream:
+    metadata:
+      name: redis
+      namespace: "{{ ansible_oc_namespace }}"
+    from: "{{ awx_redis_image_mirrored_from }}"
+    tag: >-
+      {{ awx_redis_image_mirrored_from | regex_replace("^.*:", "") }}
+
 - name: Ansible Tower StatefulSet
   openshift:
     state: latest
@@ -178,7 +188,7 @@
                     fieldPath: status.podIP
           #####################################################
           - name: awx-redis
-            image: redis:6.0
+            image: "{{ awx_redis_image_mirrored_to }}"
             imagePullPolicy: Always
             args: ["redis-server", "/etc/redis/redis.conf"]
             ports:

--- a/ansible/roles/awx-instance/tasks/pushgateway.yml
+++ b/ansible/roles/awx-instance/tasks/pushgateway.yml
@@ -41,7 +41,7 @@
         spec:
           containers:
             - name: pushgateway
-              image: prom/pushgateway
+              image: quay.io/prometheus/pushgateway
               ports:
               - containerPort: 9091
                 name: pushgateway

--- a/ansible/roles/awx-instance/templates/Dockerfile.wp-ansible-runner
+++ b/ansible/roles/awx-instance/templates/Dockerfile.wp-ansible-runner
@@ -1,5 +1,5 @@
 FROM docker-registry.default.svc:5000/{{ ansible_oc_namespace }}/{{ mgmt_image_name }}:latest
-FROM docker-registry.default.svc:5000/{{ ansible_oc_namespace }}/{{ awx_runner_base_image_name }}:latest
+FROM docker-registry.default.svc:5000/{{ ansible_oc_namespace }}/{{ awx_ansible_runner_base_image_name }}:latest
 
 RUN yum -y update
 

--- a/ansible/roles/awx-instance/vars/k8s-vars.yml
+++ b/ansible/roles/awx-instance/vars/k8s-vars.yml
@@ -1,17 +1,22 @@
 awx_version: 15.0.1
 awx_image_name: wp-awx
+awx_base_image_mirrored_from: "docker.io/ansible/awx:{{ awx_version }}"
+awx_base_image_mirrored_to: "docker-registry.default.svc:5000/wwp-test/awx:{{ awx_version }}"
 awx_image_full_name: "docker-registry.default.svc:5000/{{ ansible_oc_namespace }}/wp-awx:{{awx_version}}"
-awx_base_image_full_name: "ansible/awx:{{ awx_version }}"
 
 awx_web_hostnames:
   wwp: awx-wwp.epfl.ch
   wwp-test: awx-poc-vpsi.epfl.ch
   wwp-infra: awx-wwp-infra.epfl.ch
 
-awx_runner_base_image_name: ansible-runner
-awx_runner_base_image_fullname: docker.io/ansible/ansible-runner:latest
+awx_ansible_runner_base_image_name: ansible-runner
+awx_ansible_runner_base_image_mirrored_from: quay.io/ansible/ansible-runner:latest
+awx_ansible_runner_base_image_mirrored_to : "docker-registry.default.svc:5000/wwp-test/{{ awx_ansible_runner_base_image_name }}"
+
+awx_redis_image_mirrored_from: redis:6.0
+awx_redis_image_mirrored_to: "docker-registry.default.svc:5000/{{ ansible_oc_namespace }}/redis:6.0"
+
 awx_runner_image_name: "wp-ansible-runner"
-awx_runner_base_image_mirrored_name: "docker-registry.default.svc:5000/wwp-test/{{ awx_runner_base_image_name }}"
 
 awx_inventory: "{{ awx_inventories[ansible_oc_namespace] }}"
 awx_inventories:

--- a/ansible/roles/wordpress-openshift-namespace/tasks/monitoring.yml
+++ b/ansible/roles/wordpress-openshift-namespace/tasks/monitoring.yml
@@ -4,6 +4,16 @@
 - include_vars: secrets-wwp.yml
   tags: always
 
+- name: "Pull traefik image into {{ monitoring_traefik_base_image_mirrored_to }}"
+  delegate_to: localhost
+  tags: monitoring.prometheus
+  openshift_imagestream:
+    metadata:
+      name: traefik
+      namespace: "{{ openshift_namespace }}"
+    from: "{{ monitoring_traefik_base_image_mirrored_from }}"
+    tag: latest
+
 - name: Prometheus service
   tags: monitoring.prometheus
   openshift:
@@ -80,7 +90,7 @@
           terminationGracePeriodSeconds: 10
           containers:
             - name: prometheus
-              image: prom/prometheus
+              image: quay.io/prometheus/prometheus
               volumeMounts:
                 - name: storage
                   mountPath: /prometheus
@@ -96,7 +106,7 @@
                 - --web.console.libraries=/usr/share/prometheus/console_libraries
                 - --web.console.templates=/usr/share/prometheus/consoles/prometheus
             - name: traefik
-              image: traefik
+              image: "{{ monitoring_traefik_base_image_mirrored_to }}"
               ports:
               - containerPort: 9999
                 name: traefik
@@ -106,7 +116,7 @@
                 - name: traefik-config-dynamic
                   mountPath: /etc/traefik/dynamic
             - name: configurator
-              image: python:3.7-alpine
+              image: quay.io/ansible/python-base
               volumeMounts:
                 - name: dynamic-config
                   mountPath: /prometheus-config/dynamic

--- a/ansible/roles/wordpress-openshift-namespace/tasks/monitoring.yml
+++ b/ansible/roles/wordpress-openshift-namespace/tasks/monitoring.yml
@@ -300,7 +300,7 @@
                     - -i
                     - /srv/batch/disk-usage-report/qdirstat.NEW
                     - -p
-                    - "http://{{ monitoring_pushgateway_url }}"
+                    - "{{ monitoring_pushgateway_url }}"
                     - --webhook
                   volumeMounts:
                     - name: srv

--- a/ansible/roles/wordpress-openshift-namespace/tasks/varnish.yml
+++ b/ansible/roles/wordpress-openshift-namespace/tasks/varnish.yml
@@ -51,6 +51,16 @@
             </Instance>
         </Plugin>
 
+- name: "Pull upstream varnish image into {{ varnish_image_mirrored_to }}"
+  delegate_to: localhost
+  openshift_imagestream:
+    metadata:
+      name: varnish
+      namespace: "{{ openshift_namespace }}"
+    from: "{{ varnish_image_mirrored_from }}"
+    tag: >-
+      {{ varnish_image_mirrored_from | regex_replace("^.*:", "") }}
+
 - name: Varnish varnishkafka.conf
   openshift:
     state: latest
@@ -94,7 +104,7 @@
             - varnishd
             - -s
             - malloc,256m
-            image: "{{ varnish_image }}"
+            image: "{{ varnish_image_mirrored_to }}"
             imagePullPolicy: IfNotPresent
             name: varnish
             ports:
@@ -114,7 +124,7 @@
             - -f
             - -C
             - /etc/collectd/collectd.conf
-            image: "{{ varnish_image }}"
+            image: "{{ varnish_image_mirrored_to }}"
             imagePullPolicy: IfNotPresent
             name: collectd
             ports:
@@ -138,7 +148,7 @@
               value: default.vcl
             - name: INSTANCE
               value: varnishd
-            image: "{{ varnish_image }}"
+            image: "{{ varnish_image_mirrored_to }}"
             imagePullPolicy: IfNotPresent
             name: varnish-reload
             resources: {}
@@ -155,7 +165,7 @@
             - /etc/varnishkafka/varnishkafka.conf
             - -n
             - varnishd
-            image: "{{ varnish_image }}"
+            image: "{{ varnish_image_mirrored_to }}"
             imagePullPolicy: IfNotPresent
             name: varnish-kafka
             resources: {}

--- a/ansible/roles/wordpress-openshift-namespace/templates/prometheus-config.yml
+++ b/ansible/roles/wordpress-openshift-namespace/templates/prometheus-config.yml
@@ -19,7 +19,7 @@ scrape_configs:
   - job_name: 'pushgateway'
     honor_labels: true  # As per https://github.com/prometheus/pushgateway/blob/master/README.md#about-the-job-and-instance-labels
     static_configs:
-    - targets: ['{{ monitoring_pushgateway_url }}']
+    - targets: ['{{ monitoring_pushgateway_hostport }}']
 
   # File-based service discovery of WordPresses
   # (https://prometheus.io/docs/prometheus/latest/configuration/configuration/#file_sd_config)

--- a/ansible/roles/wordpress-openshift-namespace/vars/monitoring-vars.yml
+++ b/ansible/roles/wordpress-openshift-namespace/vars/monitoring-vars.yml
@@ -10,3 +10,6 @@ monitoring_pushgateway_namespace: >-
      else openshift_namespace }}
 monitoring_pushgateway_hostport: "pushgateway.{{ monitoring_pushgateway_namespace }}.svc:9091"
 monitoring_pushgateway_url: "http://{{ monitoring_pushgateway_hostport }}/"
+
+monitoring_traefik_base_image_mirrored_from: docker.io/library/traefik
+monitoring_traefik_base_image_mirrored_to: "docker-registry.default.svc:5000/{{ openshift_namespace }}/traefik"

--- a/ansible/roles/wordpress-openshift-namespace/vars/monitoring-vars.yml
+++ b/ansible/roles/wordpress-openshift-namespace/vars/monitoring-vars.yml
@@ -8,4 +8,5 @@ prometheus_htpass: "\n{% for cred in prometheus.credentials %}\n          - \"{{
 monitoring_pushgateway_namespace: >-
   {{ "wwp-infra" if openshift_namespace == "wwp"
      else openshift_namespace }}
-monitoring_pushgateway_url: http://pushgateway.{{ monitoring_pushgateway_namespace }}:9091/
+monitoring_pushgateway_hostport: "pushgateway.{{ monitoring_pushgateway_namespace }}.svc:9091"
+monitoring_pushgateway_url: "http://{{ monitoring_pushgateway_hostport }}/"

--- a/ansible/roles/wordpress-openshift-namespace/vars/varnish-vars.yml
+++ b/ansible/roles/wordpress-openshift-namespace/vars/varnish-vars.yml
@@ -1,1 +1,2 @@
-varnish_image: camptocamp/varnish:20181129-1
+varnish_image_mirrored_from: docker.io/camptocamp/varnish:20181129-1
+varnish_image_mirrored_to: "docker-registry.default.svc:5000/{{ openshift_namespace }}/varnish:20181129-1"

--- a/docker/logrotate/Dockerfile
+++ b/docker/logrotate/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:stretch
+FROM public.ecr.aws/debian/debian:stretch
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     gzip \

--- a/docker/varnish/Dockerfile
+++ b/docker/varnish/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:stretch
+FROM public.ecr.aws/debian/debian:stretch
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     varnish \


### PR DESCRIPTION
- Pull as many images as we can from either quay.io or public.ecr.aws
- Mirror the remaining ones
- Fix other things that prevented [prometheus-wwp](https://prometheus-wwp.epfl.ch/graph) from starting up
