### PR TITLE
[fix] `/srv/dev` is no more

### DIFF
--- a/ansible/inventory/wordpress-instances.py
+++ b/ansible/inventory/wordpress-instances.py
@@ -232,7 +232,7 @@ class _LiveSite(_Site):
 
 
 class LiveTestSite(TestSiteTrait, _LiveSite):
-    _find_in_dirs = '/srv/dev /srv/int'
+    _find_in_dirs = '/srv/int'
 
 
 class LiveProductionSite(ProdSiteTrait, _LiveSite):


### PR DESCRIPTION
After the operations in [INF-7254](https://jira.camptocamp.com/servicedesk/customer/portal/5/INF-7254) this directory doesn't exist anymore (it used to live on the test NFS share).
