### PR TITLE
[fix] do not use cache when building wp-base

### DIFF
--- a/ansible/roles/wordpress-openshift-namespace/tasks/images.yml
+++ b/ansible/roles/wordpress-openshift-namespace/tasks/images.yml
@@ -31,6 +31,7 @@
       git_path: docker/wp-base
       strategy:
         dockerStrategy:
+          noCache: true
           buildArgs:
             - name: GITHUB_API_USER
               value: "{{ github_api_token.user }}"


### PR DESCRIPTION
As in the [documentation](https://docs.openshift.com/enterprise/3.1/dev_guide/builds.html) :
> Docker builds normally reuse cached layers found on the host performing
> the build. Setting the noCache option to true forces the build to ignore
> cached layers and rerun all steps of the Dockerfile.