### PR TITLE
[fix] `-t wp.wipe`: Keep relevant bits of `.htaccess` around

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,5 +43,7 @@ script:
      -t docker-registry.default.svc:5000/wwp-test/wp-base docker/wp-base
   docker build $mgmt_build_args \
      -t docker-registry.default.svc:5000/wwp-test/mgmt docker/mgmt
-  find docker -mindepth 1 -maxdepth 1 -type d \
-    | grep -v wp-base | grep -v mgmt | xargs -t -n 1 docker build
+  for docker_dir in $(find docker -mindepth 1 -maxdepth 1 -type d \
+                      | grep -v wp-base | grep -v mgmt | xargs -t -n 1); do
+    docker build "$docker_dir"
+  done

--- a/ansible/roles/wordpress-instance/tasks/main.yml
+++ b/ansible/roles/wordpress-instance/tasks/main.yml
@@ -40,6 +40,10 @@
 # nothing if the user already took the matters in their own hands.
 
 - name: Backup
+  when: >-
+    (wp_do_backup | default(True) | bool)
+    or
+    ("wp.backup" in ansible_run_tags)
   tags:
     - never  # That is, skip unless "-t wp.wipe" or "-t wp.backup" is
              # passed on the command line

--- a/ansible/roles/wordpress-instance/tasks/wipe.yml
+++ b/ansible/roles/wordpress-instance/tasks/wipe.yml
@@ -1,5 +1,8 @@
 # Delete a WordPress site
-- include_vars: wipe-vars.yml
+- include_vars: "{{ item }}"
+  with_items:
+    - wipe-vars.yml
+    - ../../wordpress-openshift-namespace/vars/monitoring-vars.yml
 
 - name: Deactivate mainwp-child
   shell: "{{ wp_cli_command }} plugin deactivate mainwp-child"

--- a/ansible/roles/wordpress-instance/tasks/wipe.yml
+++ b/ansible/roles/wordpress-instance/tasks/wipe.yml
@@ -37,6 +37,29 @@
     path: "{{ wp_dir }}/{{ item }}"
   with_items: "{{ wipe_paths }}"
 
+- name: Does .htaccess still exist?
+  register: _stat_htaccess
+  stat:
+    path: "{{ wipe_htaccess_path }}"
+
+- name: Remove WordPress section in .htaccess
+  when: wipe_when_htaccess_still_exists
+  blockinfile:
+    path: "{{ wp_dir }}/.htaccess"
+    state: absent
+    marker: "# {mark} WordPress"
+
+- name: Delete .htaccess if empty
+  when: wipe_when_htaccess_still_exists
+  register: _delete_htaccess
+  shell:
+    cmd: |
+      if [ $(grep -vP '^\s*(#|$)' "{{ wipe_htaccess_path }}" | wc -l) -gt 0 ]; then exit 0; fi
+      echo WILL_DELETE
+      rm -f "{{ wipe_htaccess_path }}"
+  changed_when: |
+    "WILL_DELETE" in _delete_htaccess.stdout
+
 - name: Delete pushgateway data
   shell: "{{ wipe_backup_data_in_pushgateway_cmd }}"
   ignore_errors: true

--- a/ansible/roles/wordpress-instance/vars/wipe-vars.yml
+++ b/ansible/roles/wordpress-instance/vars/wipe-vars.yml
@@ -4,7 +4,6 @@ wipe_paths:
   - wp
   - wp-admin
   - wp-includes
-  - .htaccess
   - index.php
   - license.txt
   - readme.html
@@ -26,3 +25,13 @@ wipe_paths:
 
 wipe_backup_data_in_pushgateway_cmd: >-
   curl -X DELETE {{ monitoring_pushgateway_url }}metrics/job/backup/instance/{{ inventory_hostname }}
+
+wipe_htaccess_path: "{{ wp_dir }}/.htaccess"
+wipe_when_htaccess_still_exists: >-
+  {{
+  ( (_stat_htaccess | default({})).stat is defined )
+  and
+  _stat_htaccess.stat
+  and
+  "isreg" in _stat_htaccess.stat
+  }}

--- a/ansible/roles/wordpress-instance/vars/wipe-vars.yml
+++ b/ansible/roles/wordpress-instance/vars/wipe-vars.yml
@@ -25,4 +25,4 @@ wipe_paths:
   - xmlrpc.php
 
 wipe_backup_data_in_pushgateway_cmd: >-
-  curl -X DELETE http://{{ monitoring_pushgateway_url }}/metrics/job/backup/instance/{{ inventory_hostname }}
+  curl -X DELETE {{ monitoring_pushgateway_url }}metrics/job/backup/instance/{{ inventory_hostname }}

--- a/docker/collectd/Dockerfile
+++ b/docker/collectd/Dockerfile
@@ -6,7 +6,7 @@ RUN apt-get update && \
     libvarnishapi1 \
   && \
     apt-get -y autoremove && \
-    apt-get clean \\
+    apt-get clean \
   && \
     rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
- Remove only the `# BEGIN WordPress` … `# END WordPress` section in `.htaccess` at `-t wp.wipe` time
- Afterwards, delete `.htaccess` only if devoid of anything non-commenty
- Option (left undocumented on purpose) to cause `-t wp.wipe` to skip backups
- Fix other bugs that prevented `-t wp.wipe` from working at all
