### PR TITLE
[fix] (Multi-)build on bad cache

### DIFF
--- a/ansible/roles/wordpress-openshift-namespace/tasks/images.yml
+++ b/ansible/roles/wordpress-openshift-namespace/tasks/images.yml
@@ -31,6 +31,7 @@
       git_path: docker/wp-base
       strategy:
         dockerStrategy:
+          forcePull: true
           noCache: true
           buildArgs:
             - name: GITHUB_API_USER


### PR DESCRIPTION
Since `httpd` is a multi-stage build, no `FROM` rewriting takes place; in order to avoid building from a stale cache (i.e. out of a `wp-base` image that got pulled earlier), we need `forcePull: true` on this build.