### PR TITLE
[upgrade] to latest Jenkins

### DIFF
--- a/ansible/roles/wordpress-openshift-namespace/tasks/continuous-integration.yml
+++ b/ansible/roles/wordpress-openshift-namespace/tasks/continuous-integration.yml
@@ -38,32 +38,27 @@
         # this ImageStream (and pass it to the Kubernetes plug-in):
         role: jenkins-slave
 
-- name: Jenkins services
-  with_items:
-    - name: jenkins
-      portName: web
-      servicePort: 80
-      targetPort: 8080
-    - name: jenkins-jnlp
-      portName: agent
-      servicePort: 5000
-      targetPort: 5000
+- name: Jenkins service
   openshift:
     state: latest
     apiVersion: v1
     kind: Service
     metadata:
-      name: "{{ item.name }}"
+      name: jenkins
       namespace: "{{ openshift_namespace }}"
       labels:
         app: jenkins
     spec:
       type: ClusterIP
       ports:
-        - name: "{{ item.portName }}"
-          port: "{{ item.servicePort }}"
+        - name: "web"
+          port: 80
+          targetPort: 8080
           protocol: TCP
-          targetPort: "{{ item.targetPort }}"
+        - name: "jnlp"
+          port: 5000
+          targetPort: 5000
+          protocol: TCP
       selector:
         app: jenkins
         deploymentconfig: jenkins
@@ -207,6 +202,8 @@
         app: jenkins
     spec:
       host: "{{ ci_jenkins_public_hostname }}"
+      port:
+        targetPort: web
       tls:
         insecureEdgeTerminationPolicy: Redirect
         termination: edge

--- a/ansible/roles/wordpress-openshift-namespace/templates/Jenkinsfile
+++ b/ansible/roles/wordpress-openshift-namespace/templates/Jenkinsfile
@@ -34,6 +34,8 @@ pipeline {
     // except we use the declarative pipeline syntax
     // (https://github.com/jenkinsci/kubernetes-plugin/#declarative-pipeline)
     kubernetes {
+      // We run on this Jenkins cloud (the one that Camptocamp set up for us):
+      cloud 'openshift'
       // Label must be unique across the OpenShift namespace; slave pods
       // will be named after it
       label 'jenkins-slave-wwp'
@@ -42,7 +44,12 @@ pipeline {
       // (see "Jenkins infrastructure ImageStreams and builds" in
       // ../tasks/continuous-integration.yml)
       inheritFrom "{{ ci_jenkins_slave_image_name }}"
-      cloud 'openshift'
+      // Ideally we would want to not have a nodeSelector at all, but
+      // we can't
+      // (https://github.com/jenkinsci/kubernetes-plugin/pull/790).
+      // The next best thing is to stipulate a label that all nodes
+      // have (here, for an OpenShift 3.11 cluster running on Linux):
+      nodeSelector "beta.kubernetes.io/os=linux"
       // Using the "yaml" field, we can weave whichever "sidekick"
       // containers we like into the pod template. The main "jnlp"
       // container (not pictured in the YAML) comes from the parent


### PR DESCRIPTION
Now [Jenkins works](https://jenkins-wwp-test.epfl.ch/), mostly — The following known problems remain:
- Upon logging in, you get an angry Jenkins
- The worker can get evicted because it overflows its “ephemeral-diskspace” reservation (of zero i.e. it didn't make one)
- Even if the worker survives till the end, build cannot complete due to some obscure Groovy error
