### PR TITLE
[fix] Ensure the `oc` binary goes into the wp-ansible-runner image

### DIFF
--- a/ansible/roles/awx-instance/templates/Dockerfile.wp-ansible-runner
+++ b/ansible/roles/awx-instance/templates/Dockerfile.wp-ansible-runner
@@ -35,6 +35,7 @@ RUN set -o pipefail; set -e -x; yum -y install patch;                       \
     done;                                                                   \
     yum -y history undo patch
 
+COPY --from=0 /usr/local/bin/oc /usr/local/bin/
 COPY --from=0 /usr/local/bin/wp /usr/local/bin/
 COPY --from=0 /usr/local/bin/new-wp-site /usr/local/bin/new-wp-site
 RUN mkdir /home/runner/.wp-cli


### PR DESCRIPTION
It looks like RedHat stopped providing it as part of the upstream image (quay.io/ansible/ansible-runner:latest) for some reason.