### PR TITLE
[fix] Disable the `phpinfo()` function

### DIFF
--- a/docker/httpd/php.ini
+++ b/docker/httpd/php.ini
@@ -10,3 +10,6 @@ opcache.revalidate_path = 1
 
 ;; Define the default sender as "noreply@epfl.ch" to bypass SMTP authentication
 sendmail_from = "noreply@epfl.ch"
+
+;; https://go.epfl.ch/INC0468760
+disable_functions = phpinfo


### PR DESCRIPTION
As per https://go.epfl.ch/INC0468760, 12-factor with environment variables doesn't really play well with that 20th-century style function.

- Yes, there are legitimate use cases in unmanaged plug-ins. Too bad.