### PR TITLE
[fix] `ImagePullBackoff` that has been going on for a month

### DIFF
--- a/ansible/roles/wordpress-openshift-namespace/tasks/monitoring.yml
+++ b/ansible/roles/wordpress-openshift-namespace/tasks/monitoring.yml
@@ -14,6 +14,15 @@
     from: "{{ monitoring_traefik_base_image_mirrored_from }}"
     tag: latest
 
+- name: "Pull {{ monitoring_python_base_image_mirrored_from }} into {{ monitoring_python_base_image_mirrored_to }}"
+  delegate_to: localhost
+  openshift_imagestream:
+    metadata:
+      name: '{{ monitoring_python_base_image | regex_replace(":.*$", "") }}'
+      namespace: "{{ openshift_namespace }}"
+    from: "{{ monitoring_python_base_image_mirrored_from }}"
+    tag: '{{ monitoring_python_base_image | regex_replace("^.*:", "") }}'
+
 - name: Prometheus service
   tags: monitoring.prometheus
   openshift:
@@ -116,7 +125,7 @@
                 - name: traefik-config-dynamic
                   mountPath: /etc/traefik/dynamic
             - name: configurator
-              image: quay.io/ansible/python-base
+              image: "{{ monitoring_python_base_image_mirrored_to }}"
               volumeMounts:
                 - name: dynamic-config
                   mountPath: /prometheus-config/dynamic

--- a/ansible/roles/wordpress-openshift-namespace/vars/monitoring-vars.yml
+++ b/ansible/roles/wordpress-openshift-namespace/vars/monitoring-vars.yml
@@ -13,3 +13,7 @@ monitoring_pushgateway_url: "http://{{ monitoring_pushgateway_hostport }}/"
 
 monitoring_traefik_base_image_mirrored_from: docker.io/library/traefik
 monitoring_traefik_base_image_mirrored_to: "docker-registry.default.svc:5000/{{ openshift_namespace }}/traefik"
+
+monitoring_python_base_image: python:buster
+monitoring_python_base_image_mirrored_from: "docker.io/library/{{ monitoring_python_base_image }}"
+monitoring_python_base_image_mirrored_to: "docker-registry.default.svc:5000/{{ openshift_namespace }}/{{ monitoring_python_base_image }}"


### PR DESCRIPTION
[Rumor has it on the Internets](https://gitlab.com/gitlab-org/gitlab/-/issues/352551#note_839508159) that the new metadata format that quay.io likes to use, is incompatible with older Dockerd's such as the one that runs on OpenShift 3.11.

As a result, [our monitoring](https://prometheus-wwp.epfl.ch/) has been firing on three cylinders for a month now.

- Fall back to using an image from docker.io
- Must mirror it first of course