### PR TITLE
[compatibility] Affirmatively require Keybase and EYAML

### DIFF
--- a/ansible/wpsible
+++ b/ansible/wpsible
@@ -40,6 +40,8 @@ platform_check () {
             SUITCASE_DIR=$PWD/ansible-deps-cache SUITCASE_ANSIBLE_REQUIREMENTS=requirements.yml \
                         SUITCASE_PIP_EXTRA="requests bcrypt passlib mitogen==0.2.9" \
                         SUITCASE_PYTHON_VERSION="3.8.10" \
+                        SUITCASE_WITH_KEYBASE=1 \
+                        SUITCASE_WITH_EYAML=1 \
                         SUITCASE_ANSIBLE_VERSION="3.4.0" bash -x
     fi
     export PATH="$PWD/ansible-deps-cache/bin:$PATH"


### PR DESCRIPTION
A future version of the Ansible suitcase will change the default value for EYAML to not install it. Same might happen later with Keybase.