### PR TITLE
[optimize] Lazy-loaded WordPress inventory

### DIFF
--- a/ansible/.interactive-playbooks/inventory_plugins/lazy_inventory.py
+++ b/ansible/.interactive-playbooks/inventory_plugins/lazy_inventory.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8; -*-
+
+# All rights reserved. © ECOLE POLYTECHNIQUE FEDERALE DE LAUSANNE, Switzerland, 2021
+
+import os
+
+from ansible.plugins.inventory import BaseInventoryPlugin
+from ansible.plugins.inventory.script import InventoryModule as ScriptInventory
+from ansible.plugins.inventory.yaml   import InventoryModule as YAMLInventory
+
+
+DOCUMENTATION = '''
+    inventory: lazy_inventory
+    plugin_type: inventory
+    short_description: Only render the inventory for real the second time it gets called.
+    description: |
+      This is to implement “lazy” inventory sources, that only do real work after
+      `meta: refresh_inventory` gets called on purpose (after the playbook
+      figures out that it does need the full inventory, e.g. from the set of
+      tags in use).
+    options:
+      lazy_inventory:
+        description: Describes the fake inventory to return the first time around
+        type: dict
+      full_inventory:
+        description: Describes the complete inventory to return the second time around
+        type: dict
+'''
+
+
+EXAMPLES = '''
+plugin: lazy_inventory
+lazy_inventory:
+  # The first time around (i.e. at ansible-playbook initialization time),
+  # render an empty group:
+  literal:
+    this_group_intentionally_left_blank:
+      hosts: {}
+full_inventory:
+  # The second time around (i.e. after `meta: refresh_inventory`),
+  # jump to the "real" script (whose path may be specified relative
+  # to the inventory plugin YAML configuration file):
+  script: my-costly-inventory-script.py
+'''
+
+
+class Counter:
+    def __init__(self):
+        self._counter = 0
+
+    def get_value_and_increment(self):
+        retval = self._counter
+        self._counter += 1
+        return retval
+
+
+class InventoryModule(BaseInventoryPlugin):
+    _execution_counter = Counter()
+
+    def parse(self, inventory, loader, path, cache):
+        super(InventoryModule, self).parse(inventory, loader, path, cache)
+        self._lazy_config_path = path
+        self.homedir = os.path.dirname(path)
+
+        self.set_options(
+            # ... from DOCUMENTATION, above, with...
+            direct=loader.load_from_file(path, cache=False))
+        lazy_inventory = self.get_option("lazy_inventory")
+        full_inventory = self.get_option("full_inventory")
+        self._delegate_parse(
+            inventory,
+            full_inventory if self._execution_counter.get_value_and_increment() >= 1
+                           else lazy_inventory)
+
+    def _delegate_parse(self, inventory, descriptor):
+        """Delegate to one of the Ansible inventory plug-ins according to `descriptor`."""
+        if "literal" in descriptor:
+            inventory_data = descriptor["literal"]
+            class FakeLoader:
+                def load_from_file(_self, path, **kwargs):
+                    return inventory_data
+                def get_basedir(_self):
+                    return self.homedir
+
+            delegate_class = YAMLInventory
+            loader = FakeLoader()
+            path = self._lazy_config_path
+
+        elif "script" in descriptor:
+            delegate_class = ScriptInventory
+            loader = self.loader
+            path = os.path.join(self.homedir, descriptor["script"])
+
+        else:
+            raise ValueError("Cannot figure out what to do from configuration keys: " +
+                             ", ".join(descriptor.keys()))
+
+
+        class DelegateLoader(delegate_class):
+            def set_options(self):
+                pass
+        return DelegateLoader().parse(inventory, loader, path, cache=False)

--- a/ansible/.interactive-playbooks/main.yml
+++ b/ansible/.interactive-playbooks/main.yml
@@ -11,28 +11,29 @@
         msg: |
           You must update Ansible to at least 2.6 to use this playbook.
 
-- name: WordPress instances
-  hosts: |
-    {%- if _want_wordpress_inventory -%}
-    {# Note: we are twisting the Ansible concept of “hosts” in this play.
-     # An inventory entry in the all_wordpresses group is a WordPress
-     # instance, rather than a host in the “traditional” sysadmin sense.
-     #}
-    all_wordpresses
-    {%- else -%}
-    {# If no relevant tags are in use (including the implicit "all" tag when -t is not
-     # present on the command line), skip the whole role and save a big chunk of time:
-     #}
-    !all
-    {%- endif -%}
+- name: Lazy-load WordPress inventory now (according to Ansible tags)
+  # See explanations in ../inventory/lazy-wordpress-instances.yml
+  hosts: localhost
   gather_facts: no    # Ansible facts are useless for this play
-  roles:
-    - role: ../roles/wordpress-instance
+  tasks:
+    # "[WARNING]: refresh_inventory task does not support when conditional"
+    - meta: end_play
+      when: not _want_wordpress_inventory
+    - meta: refresh_inventory
   vars:
     _want_wordpress_inventory: >-
           {{ ansible_run_tags | any_known_tag(_wordpress_instance_role_path) }}
     _wordpress_instance_role_path: >-
           {{ (playbook_dir | dirname) + "/roles/wordpress-instance" }}
+
+- name: WordPress instances
+  # Note: we are twisting the Ansible concept of “hosts” in this play.
+  # An inventory entry in the all_wordpresses group is a WordPress
+  # instance, rather than a host in the “traditional” sysadmin sense.
+  hosts: all_wordpresses
+  gather_facts: no    # Ansible facts are useless for this play
+  roles:
+    - role: ../roles/wordpress-instance
 
 - name: OpenShift namespaces
   # Like above, members of the all_openshift_namespaces are OpenShift

--- a/ansible/.interactive-playbooks/main.yml
+++ b/ansible/.interactive-playbooks/main.yml
@@ -13,9 +13,7 @@
 
 - name: WordPress instances
   hosts: |
-    {%- if (ansible_run_tags |
-                          any_known_tag((playbook_dir | dirname) +
-                                        "/roles/wordpress-instance")) -%}
+    {%- if _want_wordpress_inventory -%}
     {# Note: we are twisting the Ansible concept of “hosts” in this play.
      # An inventory entry in the all_wordpresses group is a WordPress
      # instance, rather than a host in the “traditional” sysadmin sense.
@@ -30,6 +28,11 @@
   gather_facts: no    # Ansible facts are useless for this play
   roles:
     - role: ../roles/wordpress-instance
+  vars:
+    _want_wordpress_inventory: >-
+          {{ ansible_run_tags | any_known_tag(_wordpress_instance_role_path) }}
+    _wordpress_instance_role_path: >-
+          {{ (playbook_dir | dirname) + "/roles/wordpress-instance" }}
 
 - name: OpenShift namespaces
   # Like above, members of the all_openshift_namespaces are OpenShift

--- a/ansible/.interactive-playbooks/main.yml
+++ b/ansible/.interactive-playbooks/main.yml
@@ -30,7 +30,8 @@
   # Note: we are twisting the Ansible concept of “hosts” in this play.
   # An inventory entry in the all_wordpresses group is a WordPress
   # instance, rather than a host in the “traditional” sysadmin sense.
-  hosts: all_wordpresses
+  hosts: all_wordpresses  # Will be an empty group, unless `- meta: refresh_inventory` above
+                          # ran
   gather_facts: no    # Ansible facts are useless for this play
   roles:
     - role: ../roles/wordpress-instance

--- a/ansible/ansible.cfg
+++ b/ansible/ansible.cfg
@@ -11,3 +11,6 @@ callback_whitelist = timer, profile_tasks
 ;; default is 5
 forks = 5
 strategy_plugins = ansible-deps-cache/python/lib/python3.7/site-packages/ansible_mitogen/plugins/strategy
+
+[inventory]
+enable_plugins = lazy_inventory

--- a/ansible/inventory/lazy-wordpress-instances.yml
+++ b/ansible/inventory/lazy-wordpress-instances.yml
@@ -1,0 +1,18 @@
+# When running wpsible interactively in ansible-playbook mode,
+# WordPress instances are only enumerated on-demand i.e. after the
+# playbook calls `meta: refresh_inventory`. This saves time and
+# resources when we won't be running anything on any WordPress
+# instances (given the set of tags passed to wpsible).
+plugin: lazy_inventory
+lazy_inventory:
+  # The first time around (i.e. at ansible-playbook initialization time),
+  # render an empty group for all_wordpresses, which will cause the
+  # entire roles/wordpress-instance to be optimized out (unless
+  # ../.interactive-playbooks/main.yml runs `meta: refresh_inventory` first):
+  literal:
+    all_wordpresses:
+      hosts: {}
+full_inventory:
+  # The second time around (i.e. after `meta: refresh_inventory`),
+  # jump to the "real" script:
+  script: wordpress-instances.py

--- a/ansible/wpsible
+++ b/ansible/wpsible
@@ -60,7 +60,12 @@ oc_check () {
 
 inventory_mode="test"
 inventories () {
-    echo "-i inventory/wordpress-instances.py"
+    case "$mode" in
+        ansible-playbook)
+            echo "-i inventory/lazy-wordpress-instances.yml" ;;
+        *)
+            echo "-i inventory/wordpress-instances.py" ;;
+    esac
     case "$inventory_mode" in
         test) echo "-i inventory/test" ;;
         test_and_prod) echo "-i inventory/test -i inventory/prod" ;;


### PR DESCRIPTION
This is a “same player shoots again” reincarnation of #434.

Loading the inventory from `wordpress-instances.py` takes some time (or even a long time) because it needs to `find(1)` all the sites over NFS. There is already support in the Ansible code base to skip `roles/wordpress-instance` when it can be worked out from the tags that we don't need it; this PR likewise makes sure to skip the useless inventory step.

- Introduce a `lazy_inventory` [inventory plugin](https://docs.ansible.com/ansible/latest/dev_guide/developing_inventory.html#developing-an-inventory-plugin), which discriminates between “lazy” and “diligent” modes according to the number of times it runs (i.e. one must run `meta: refresh_inventory` to get the full inventory)
- Do exactly that in `.interactive-playbooks/main.yml` before we run `roles/wordpress-instance`. If we don't, then the `all_wordpresses` group stays empty (from the “fake” inventory) and therefore the role gets skipped, as it did before
