### PR TITLE
[unfeature] Disable cache “optimization”

### DIFF
--- a/ansible/roles/awx-instance/templates/Dockerfile.wp-ansible-runner
+++ b/ansible/roles/awx-instance/templates/Dockerfile.wp-ansible-runner
@@ -62,6 +62,3 @@ RUN set -e -x; mkdir /tmp/install; \
     ansible-galaxy install -i -r /tmp/install/requirements.yml ; \
     ansible-galaxy collection install -i -r /tmp/install/requirements.yml ; \
     rm /tmp/install/requirements.yml
-
-# Activate cache in wordpress_plugin.py
-ENV WPSIBLE_WPCLI_CACHE_DIR=/tmp/wordpress_plugin-cache


### PR DESCRIPTION
- It just broke a manual AWX run, perhaps on account of `/tmp/wordpress_plugin-cache` not existing
- It is a dead-end prototyping idea, which even if it worked, wouldn't advance our goal (which was to run Ansible continuously every 30 minutes Puppet-style on each site, which is just not a reasonable use of our compute resources)