### PR TITLE
Allow to specify a conditional plugin install, based on the current wp version

### DIFF
--- a/docker/wp-base/Dockerfile
+++ b/docker/wp-base/Dockerfile
@@ -113,8 +113,9 @@ ADD install-plugins-and-themes.py clearstatcache-wp-import.patch /tmp/
 # Get all plugins and themes (in "auto" mode) out of the Ansible
 # `plugins.yml` file:
 ARG INSTALL_AUTO_FLAGS
-RUN set -e -x; for wp in /wp/*; do cd $wp ;                              \
-        /tmp/install-plugins-and-themes.py auto ${INSTALL_AUTO_FLAGS};   \
+RUN set -e -x; for wp in /wp/*; do cd $wp ;                                                      \
+        wpversion=$(echo ${wp#"/wp/"});                                                          \
+        /tmp/install-plugins-and-themes.py auto ${INSTALL_AUTO_FLAGS} --wp-version ${wpversion}; \
     done
 
 # Special treatment for tinymce-advanced, whose version scheme follows


### PR DESCRIPTION
- Added the --wp-version paramaters to install-plugins-and-themes.py
- Should be compatible with Ansible, thanks to this change 002a61f14eed9cdeba339e061c24738aa47b4403

Example of usage :
```
- name: Polylang for WP 5.5 plugin
  when: wp_current_version < 5.6
  wordpress_plugin:
    name: polylang
    state:
      - symlinked
      - active
    from: https://downloads.wordpress.org/plugin/polylang.2.9.2.zip

- name: Polylang plugin
  when: wp_current_version >= 5.6
  wordpress_plugin:
    name: polylang
    state:
      - symlinked
      - active
    from: wordpress.org/plugins
```