### PR TITLE
Add a way to select a specific branch when getting a Plugin from Github

### DIFF
--- a/ansible/roles/wordpress-instance/action_plugins/wordpress_action_module.py
+++ b/ansible/roles/wordpress-instance/action_plugins/wordpress_action_module.py
@@ -136,9 +136,13 @@ class WordPressActionModule(ActionBase):
             # _is_filename should be true for URLs of files and (by extension)
             # of directories that are to be “cherry-picked” (rather than
             # cloned) out of a fraction of a repository. On the other hand,
-            # “other” things on GitHub (such as a whole repository, or a
-            # released .zip) should return false.
-            return re.search(r'/(tree|blob)/', from_piece)
+            # “other” things on GitHub (such as a whole repository, with or without a
+            # specified branch, or a released .zip) should return false.
+            # if it has a branch, it's a full repo with a tree in the url
+            if self._task.args.get('branch'):
+                return
+            else:
+                return re.search(r'/(tree|blob)/', from_piece)
         else:
             return (from_piece != "wordpress.org/plugins"
                     and not from_piece.endswith(".zip"))

--- a/ansible/roles/wordpress-instance/tasks/plugins.yml
+++ b/ansible/roles/wordpress-instance/tasks/plugins.yml
@@ -371,7 +371,8 @@
     state:
       - symlinked
       - active
-    from: https://github.com/epfl-si/wp-gutenberg-epfl/tree/update/5.9
+    from: https://github.com/epfl-si/wp-gutenberg-epfl
+    branch: update/5.9
 
 - name: EPFL Menus plugin
   wordpress_plugin:

--- a/docker/wp-base/install-plugins-and-themes.py
+++ b/docker/wp-base/install-plugins-and-themes.py
@@ -103,7 +103,7 @@ class Tempdir:
 class GitHubCheckout:
     """A subdirectory found on GitHub, designated by its URL."""
 
-    def __init__(self, url):
+    def __init__(self, url, branch=None):
         """Class constructor.
 
         @param url The URL to `git clone` from. Shall start with
@@ -112,6 +112,7 @@ class GitHubCheckout:
         subdirectory (e.g. `https://github.com/foo/bar/tree/mybranch/sub/dir`)
         """
         self.url = url
+        self._branch = branch
         self._parsed = self._parse(url)
         assert self._parsed
 
@@ -138,10 +139,13 @@ class GitHubCheckout:
 
     @property
     def branch(self):
-        try:
-            return self._parsed.group(3)
-        except IndexError:
-            return None
+        if self._branch:
+            return self._branch
+        else:
+            try:
+                return self._parsed.group(3)
+            except IndexError:
+                return None
 
     @property
     def path_under_git_root(self):
@@ -183,16 +187,16 @@ class GitHubCheckout:
 class Plugin(object):
     """A WordPress plug-in or theme."""
 
-    def __init__(self, name, urls, **unused_kwargs):
+    def __init__(self, name, urls, **uncommon_kwargs):
         self.name = name
         self.urls = urls
 
-    def __new__(cls, name, urls):
+    def __new__(cls, name, urls, **uncommon_kwargs):
         if cls is Plugin:
             cls = cls._find_handler(urls[0])
 
         that = object.__new__(cls)
-        that.__init__(name, urls)
+        that.__init__(name, urls, **uncommon_kwargs)
         return that
 
     @staticmethod
@@ -225,8 +229,8 @@ class ZipPlugin(Plugin):
     def handles(cls, url):
         return url.endswith(".zip")
 
-    def __init__(self, name, urls):
-        super(ZipPlugin, self).__init__(name, urls)
+    def __init__(self, name, urls, **uncommon_kwargs):
+        super(ZipPlugin, self).__init__(name, urls, **uncommon_kwargs)
         assert len(self.urls) == 1
         self.url = self.urls[0]
         assert self.url.startswith("http")
@@ -270,8 +274,9 @@ class GitHubPlugin(Plugin):
     def handles(cls, url):
         return GitHubCheckout.is_valid(url)
 
-    def __init__(self, name, urls):
-        super(GitHubPlugin, self).__init__(name, urls)
+    def __init__(self, name, urls, **uncommon_kwargs):
+        super(GitHubPlugin, self).__init__(name, urls, **uncommon_kwargs)
+        self.branch = uncommon_kwargs.get('branch')
         self._gits = [GitHubCheckout(url) for url in self.urls]
 
     def install(self, target_dir, rename_like_self=True):
@@ -299,8 +304,8 @@ class S3Plugin(Plugin):
     def set_client(cls, client):
         cls.client = client
 
-    def __init__(self, name, urls):
-        super(S3Plugin, self).__init__(name, urls)
+    def __init__(self, name, urls, **uncommon_kwargs):
+        super(S3Plugin, self).__init__(name, urls, **uncommon_kwargs)
         assert len(self.urls) == 1
         self.url = self.urls[0]
         assert self.handles(self.url)
@@ -400,6 +405,9 @@ class WpOpsPlugins:
 
             name = options['name']
             urls = options['from']
+            uncommon_kwargs = {}  # the others entries, for some specific implementation
+            if options.get('branch'):
+                uncommon_kwargs['branch'] = options['branch']
             if isinstance(urls, string_types):
                 urls = [urls]
 
@@ -417,10 +425,10 @@ class WpOpsPlugins:
                     raise Exception(pprint.pformat(thing))
                 # install only if the 'when' condition is met
                 if self.OPERATORS[when_part_operator](LooseVersion(self.wp_version), LooseVersion(when_part_version)):
-                    yield (Plugin(name, urls), is_mu)
+                    yield (Plugin(name, urls, **uncommon_kwargs), is_mu)
             else:
                 # go for it without any conditions !
-                yield (Plugin(name, urls), is_mu)
+                yield (Plugin(name, urls, **uncommon_kwargs), is_mu)
 
     def plugins(self):
         """Yield all the plug-ins to be installed according to the "ops" metadata."""


### PR DESCRIPTION
I had to go this path because when we use a direct branch url (like github.com/epfl-si/wp-gutenberg/tree/update/5.9) for a checkout, the script has no way to differentiate if it is a branch to checkout or a subfolder/file to get (see https://github.com/epfl-si/wp-ops/blob/bb25026b30b4dc804a6bb1271bb28bece060fa67/ansible/roles/wordpress-instance/action_plugins/wordpress_action_module.py#L141)