### PR TITLE
[feature] Configuration-as-code for Jenkins + capability to send emails

### DIFF
--- a/ansible/roles/wordpress-openshift-namespace/tasks/continuous-integration.yml
+++ b/ansible/roles/wordpress-openshift-namespace/tasks/continuous-integration.yml
@@ -18,6 +18,15 @@
       git: "{{ ci_jenkins_master_git_build }}"
     - name: "{{ ci_jenkins_test_sidekick_image_name }}"
       git: "{{ ci_jenkins_test_sidekick_git_build }}"
+  register: _jenkins_build
+
+- name: "Rebuild Jenkins images now"
+  when: _jenkins_build is changed
+  shell: "oc -n {{ openshift_namespace }} start-build --wait {{ item }}"
+  delegate_to: localhost
+  with_items:
+    - "{{ ci_jenkins_master_image_name }}"
+    - "{{ ci_jenkins_test_sidekick_image_name }}"
 
 # This ImageStream is intended as a so-called "Kubernetes plug-in pod
 # template", that the Jenkinsfile can reference (or inheritFrom, in

--- a/ansible/roles/wordpress-openshift-namespace/tasks/continuous-integration.yml
+++ b/ansible/roles/wordpress-openshift-namespace/tasks/continuous-integration.yml
@@ -157,8 +157,9 @@
                 limits:
                   memory: 2Gi
               volumeMounts:
-              - mountPath: /var/lib/jenkins
+              - mountPath: /var/lib/jenkins/jobs
                 name: jenkins-data
+                subPath: jobs
           securityContext: {}
           serviceAccount: jenkins
           serviceAccountName: jenkins

--- a/ansible/roles/wordpress-openshift-namespace/tasks/continuous-integration.yml
+++ b/ansible/roles/wordpress-openshift-namespace/tasks/continuous-integration.yml
@@ -166,6 +166,9 @@
               - mountPath: /var/lib/jenkins/jobs
                 name: jenkins-data
                 subPath: jobs
+              - mountPath: /var/lib/jenkins/logs
+                name: jenkins-data
+                subPath: logs
           securityContext: {}
           serviceAccount: jenkins
           serviceAccountName: jenkins

--- a/ansible/roles/wordpress-openshift-namespace/tasks/continuous-integration.yml
+++ b/ansible/roles/wordpress-openshift-namespace/tasks/continuous-integration.yml
@@ -21,12 +21,18 @@
   register: _jenkins_build
 
 - name: "Rebuild Jenkins images now"
-  when: _jenkins_build is changed
+  when: |
+    (
+    _jenkins_build is changed
+    or
+    ("ci.rebuild" in ansible_run_tags)
+    )
   shell: "oc -n {{ openshift_namespace }} start-build --wait {{ item }}"
   delegate_to: localhost
   with_items:
     - "{{ ci_jenkins_master_image_name }}"
     - "{{ ci_jenkins_test_sidekick_image_name }}"
+  tags: ci.rebuild
 
 # This ImageStream is intended as a so-called "Kubernetes plug-in pod
 # template", that the Jenkinsfile can reference (or inheritFrom, in

--- a/ansible/roles/wordpress-openshift-namespace/tasks/continuous-integration.yml
+++ b/ansible/roles/wordpress-openshift-namespace/tasks/continuous-integration.yml
@@ -71,8 +71,8 @@
           targetPort: 8080
           protocol: TCP
         - name: "jnlp"
-          port: 5000
-          targetPort: 5000
+          port: 50000
+          targetPort: 50000
           protocol: TCP
       selector:
         app: jenkins

--- a/ansible/roles/wordpress-openshift-namespace/tasks/main.yml
+++ b/ansible/roles/wordpress-openshift-namespace/tasks/main.yml
@@ -55,6 +55,7 @@
   # Jenkinsfile inside
   tags:
     - ci
+    - ci.rebuild
     - ci.services
     - ci.jenkinsfile
 

--- a/docker/jenkins/Dockerfile
+++ b/docker/jenkins/Dockerfile
@@ -3,3 +3,7 @@ MAINTAINER EPFL ISAS-FSD <isas-fsd@groupes.epfl.ch>
 
 COPY epfl-plugins.txt /opt/openshift
 RUN /usr/local/bin/install-plugins.sh /opt/openshift/epfl-plugins.txt
+
+# https://plugins.jenkins.io/configuration-as-code/
+COPY configuration-as-code.yml /opt/openshift/configuration-as-code/configuration-as-code.yml
+ENV CASC_JENKINS_CONFIG /opt/openshift/configuration-as-code/configuration-as-code.yml

--- a/docker/jenkins/configuration-as-code.yml
+++ b/docker/jenkins/configuration-as-code.yml
@@ -1,0 +1,14 @@
+# These configuration directives override the current Jenkins state at
+# start-up time.
+#
+# See documentation at https://plugins.jenkins.io/configuration-as-code/
+
+# As found at https://github.com/jenkinsci/email-ext-plugin/blob/master/src/test/resources/configuration-as-code.yml :
+unclassified:
+  mailer:
+    replyToAddress: noreply@epfl.ch
+    smtpHost: mail.epfl.ch
+  email-ext:
+    mailAccount:
+      smtpHost: mail.epfl.ch
+      useTls: true

--- a/docker/jenkins/epfl-plugins.txt
+++ b/docker/jenkins/epfl-plugins.txt
@@ -1,2 +1,3 @@
 cucumber-reports
 htmlpublisher
+email-ext

--- a/docker/jenkins/epfl-plugins.txt
+++ b/docker/jenkins/epfl-plugins.txt
@@ -1,3 +1,4 @@
 cucumber-reports
 htmlpublisher
 email-ext
+configuration-as-code

--- a/docker/jenkins/epfl-plugins.txt
+++ b/docker/jenkins/epfl-plugins.txt
@@ -1,4 +1,4 @@
 cucumber-reports
 htmlpublisher
-email-ext
-configuration-as-code
+email-ext:2.88
+configuration-as-code:1466.v2d4119502006


### PR DESCRIPTION
- Overhaul the Jenkins setup that Camptocamp did for us. Instead of mounting /var/lib/jenkins on NFS whole (and thus making it all persistent, including the configuration, the set of plug-ins etc.), only mount /var/lib/jenkins/jobs and /var/lib/jenkins/logs
- Deploy and use the [configuration-as-code plugin](https://plugins.jenkins.io/configuration-as-code/)
- ... And that's it — As it turns out, OpenShift's default configuration for Jenkins gets a lot of things right without having to touch (including access control).

Also:
 
- It appears that the JNLP port moved from 5000 to 50000 for some reason. Fix that.
- Change Ansible code to rebuild Jenkins images whenever the `BuildConfig` / `ImageStream` objects change, and/or when explicitly told (using `wpsible -t ci.rebuild`).