### PR TITLE
Remove backups-0 ("/backups" in mgmt) from the DeploymentConfig

### DIFF
--- a/ansible/roles/wordpress-openshift-namespace/tasks/mgmt.yml
+++ b/ansible/roles/wordpress-openshift-namespace/tasks/mgmt.yml
@@ -92,8 +92,6 @@
               mountPath: /srv
             - name: ssh
               mountPath: /var/lib/secrets/ssh
-            - name: backups
-              mountPath: /backups
             envFrom:
               - configMapRef:
                   name: new-wp-site-env
@@ -110,12 +108,6 @@
           - name: ssh
             secret:
               secretName: "{{ mgmt_ssh_secret_name }}"
-          - >-
-            {{ { "name": "backups",
-                 "persistentVolumeClaim": {"claimName": "backups-0"} }
-               if openshift_is_production
-               else { "name": "backups", "emptydir": {} }
-            }}
       triggers:
       - type: ConfigChange
       - type: ImageChange


### PR DESCRIPTION
As we changed backups strategy from the NFS to S3, we need to remove the unused volumeClaim /backups.

See https://jira.camptocamp.com/servicedesk/customer/portal/5/INF-9392 for more info.