### PR TITLE
[fix] silly deadlock in AWX

### DIFF
--- a/ansible/roles/awx-instance/tasks/container-group.yml
+++ b/ansible/roles/awx-instance/tasks/container-group.yml
@@ -51,6 +51,7 @@
       with AnsibleGetOrCreate(InstanceGroup,
                   name="{{ awx_elastic_container_group_name }}") as instance_group:
           instance_group.credential = cred
+          instance_group.policy_instance_minimum = 1
           instance_group.pod_spec_override = """
       apiVersion: v1
       kind: Pod


### PR DESCRIPTION
I'm not sure what a “policy instance minimum” (in French: «instances de stratégies minimum») is precisely; but I do know that when that is set to 0, AWX makes no progress and keeps tasks in the waiting state (white dot) forever.