### PR TITLE
[fix] Explicit triggers for images that depend (directly or indirectly) on `wp-base`

### DIFF
--- a/ansible/roles/wordpress-openshift-namespace/tasks/images.yml
+++ b/ansible/roles/wordpress-openshift-namespace/tasks/images.yml
@@ -130,7 +130,7 @@
         ref: "{{ images_build_branch }}"
     strategy: "{{ item.strategy | default({}) }}"
     triggers: >-
-      {{ [_wp_base_trigger] if (item.triggered_by_wp_base | default(False)) else [] }}
+      {{ [_triggers[item.triggered_by]] if item.triggered_by is defined else [] }}
   with_items:
     - name: "{{ wp_base_image_name }}"
       git_path: docker/wp-base
@@ -158,22 +158,22 @@
     - name: "{{ httpd_image_name }}"
       git_path: docker/httpd
       from: "{{ wp_base_image_name }}"
-      triggered_by_wp_base: true
+      triggered_by: wp-base
     - name: "{{ mgmt_image_name }}"
       git_path: docker/mgmt
       from: "{{ wp_base_image_name }}"
-      triggered_by_wp_base: true
+      triggered_by: wp-base
     - name: "{{ backup_cron_image_name }}"
       git_path: docker/cronjob
-      from: "{{ mgmt_image_name }}"
   vars:
-    _wp_base_trigger:
-      type: ImageChange
-      imageChange:
-        from:
-          kind: ImageStreamTag
-          namespace: "{{ openshift_namespace }}"
-          name: "{{ wp_base_image_name }}:latest"
+    _triggers:
+      wp-base:
+        type: ImageChange
+        imageChange:
+          from:
+            kind: ImageStreamTag
+            namespace: "{{ openshift_namespace }}"
+            name: "{{ wp_base_image_name }}:latest"
   tags: images.build
 
 - name: "Production ImageStreams"

--- a/ansible/roles/wordpress-openshift-namespace/tasks/images.yml
+++ b/ansible/roles/wordpress-openshift-namespace/tasks/images.yml
@@ -165,6 +165,8 @@
       triggered_by: wp-base
     - name: "{{ backup_cron_image_name }}"
       git_path: docker/cronjob
+      from: "{{ mgmt_image_name }}"
+      triggered_by: mgmt
   vars:
     _triggers:
       wp-base:
@@ -174,6 +176,13 @@
             kind: ImageStreamTag
             namespace: "{{ openshift_namespace }}"
             name: "{{ wp_base_image_name }}:latest"
+      mgmt:
+        type: ImageChange
+        imageChange:
+          from:
+            kind: ImageStreamTag
+            namespace: "{{ openshift_namespace }}"
+            name: "{{ mgmt_image_name }}:latest"
   tags: images.build
 
 - name: "Production ImageStreams"

--- a/ansible/roles/wordpress-openshift-namespace/tasks/images.yml
+++ b/ansible/roles/wordpress-openshift-namespace/tasks/images.yml
@@ -129,6 +129,8 @@
         path: "{{ item.git_path }}"
         ref: "{{ images_build_branch }}"
     strategy: "{{ item.strategy | default({}) }}"
+    triggers: >-
+      {{ [_wp_base_trigger] if (item.triggered_by_wp_base | default(False)) else [] }}
   with_items:
     - name: "{{ wp_base_image_name }}"
       git_path: docker/wp-base
@@ -156,12 +158,22 @@
     - name: "{{ httpd_image_name }}"
       git_path: docker/httpd
       from: "{{ wp_base_image_name }}"
+      triggered_by_wp_base: true
     - name: "{{ mgmt_image_name }}"
       git_path: docker/mgmt
       from: "{{ wp_base_image_name }}"
+      triggered_by_wp_base: true
     - name: "{{ backup_cron_image_name }}"
       git_path: docker/cronjob
       from: "{{ mgmt_image_name }}"
+  vars:
+    _wp_base_trigger:
+      type: ImageChange
+      imageChange:
+        from:
+          kind: ImageStreamTag
+          namespace: "{{ openshift_namespace }}"
+          name: "{{ wp_base_image_name }}:latest"
   tags: images.build
 
 - name: "Production ImageStreams"


### PR DESCRIPTION
Not sure how this worked in the first place: did the behavior of `openshift_imagestream` allow for a more liberal kind of implicit chaining in the past? Or was that piece of the `BuildConfig` added by hand? Anyway, today we saw that the assumption that Jenkins makes (that launching a `wp-base` build, will trigger the others automatically) no longer holds.

Fix that by having explicit `triggers:` stanzas in the configuration-as-code (instead of relying on whatever aforementioned technique we used for triggers previously