### PR TITLE
[fix] oc login

### DIFF
--- a/ansible/wpsible
+++ b/ansible/wpsible
@@ -53,7 +53,7 @@ platform_check () {
 oc_check () {
   if ! oc projects >/dev/null 2>&1; then
     echo "Please login to openshift:"
-    oc login
+    oc login --username $USER
   fi
 }
 


### PR DESCRIPTION
Now with the `--username` set to `$USER`. This allows the user to enter its password instead of login to OpenShift to fetch its token.