### PR TITLE
[upgrade] Debian images to `bullseye`

### DIFF
--- a/docker/logrotate/Dockerfile
+++ b/docker/logrotate/Dockerfile
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/debian/debian:buster
+FROM public.ecr.aws/debian/debian:bullseye
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     gzip \

--- a/docker/logrotate/Dockerfile
+++ b/docker/logrotate/Dockerfile
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/debian/debian:stretch
+FROM public.ecr.aws/debian/debian:buster
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     gzip \

--- a/docker/varnish/Dockerfile
+++ b/docker/varnish/Dockerfile
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/debian/debian:buster
+FROM public.ecr.aws/debian/debian:bullseye
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     varnish \

--- a/docker/varnish/Dockerfile
+++ b/docker/varnish/Dockerfile
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/debian/debian:stretch
+FROM public.ecr.aws/debian/debian:buster
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     varnish \


### PR DESCRIPTION
As per https://www.debian.org/releases/stretch/index.en.html it looks like Debian Stretch is dead.