### PR TITLE
Set flowpaper plugin as direct link

### DIFF
--- a/ansible/roles/wordpress-instance/tasks/plugins.yml
+++ b/ansible/roles/wordpress-instance/tasks/plugins.yml
@@ -232,7 +232,10 @@
     state:
       - symlinked
       - active
-    from: wordpress.org/plugins
+    # As the plugin has to be reviewed by the WP team, temporary get the direct plugin zip,
+    # please reset later to:
+    # from: wordpress.org/plugins
+    from: https://downloads.wordpress.org/plugin/flowpaper-lite-pdf-flipbook.zip
   tags: wp.plugins.pdf
 
 - name: Remove obsolete PDF plug-ins (one-shot action)


### PR DESCRIPTION
As the wordpress.org link need to be reviewed by the WP team.

https://wordpress.org/plugins/flowpaper-lite-pdf-flipbook