### PR TITLE
[fix] Time out the backup step after 8h

### DIFF
--- a/ansible/roles/wordpress-instance/tasks/backup.yml
+++ b/ansible/roles/wordpress-instance/tasks/backup.yml
@@ -16,6 +16,7 @@
     - "../../../vars/secrets-{{ openshift_namespace }}.yml"  # Used in env-secrets.yml
 
 - name: Backup
+  timeout: "{{ backup_timeout_seconds }}"
   environment: "{{ backup_restic_environment }}"    # `-vv`-safe!
   shell:
     executable: /bin/bash

--- a/ansible/roles/wordpress-instance/vars/backup-vars.yml
+++ b/ansible/roles/wordpress-instance/vars/backup-vars.yml
@@ -20,6 +20,8 @@ backup_aws_s3api_jq_sum_cmd: >-
 backup_aws_s3api_jq_count_cmd: >-
   jq '.Contents | length'
 
+backup_timeout_seconds: "{{ 8 * 3600 }}"  # 8 hours
+
 backup_url_label: "{{ wp_base_url | ensure_trailing_slash }}"
 backup_curl_to_pushgateway_cmd: >-
   curl -X POST -H "Content-Type: text/plain" --data-binary @-


### PR DESCRIPTION
Right now, and for reasons yet unknown, the “Backup” task for `www__labs__dcsl` takes *days* and we get an alert for that site.

Given that the last log line at https://awx-wwp-infra.epfl.ch/#/jobs/playbook/5288 is currently dated 2023-09-27T01:16:56.110490Z; while the task headline (“Backup”) (i.e. the event `playbook_on_task_start`, which is the first item in https://awx-wwp-infra.epfl.ch/api/v2/jobs/5288/job_events/?counter__gte=8017&counter__lte=8062&order_by=start_line&page_size=200 ) is dated 2023-09-26T19:28:51.624270Z; 6h ought to be enough, but since the actual deadline is 24h (i.e. before the next crontab starts) we can add 2 hours of slack.