### PR TITLE
[feature] say no to "cowsay"

### DIFF
--- a/ansible/ansible.cfg
+++ b/ansible/ansible.cfg
@@ -11,3 +11,4 @@ callback_whitelist = timer, profile_tasks
 ;; default is 5
 forks = 5
 strategy_plugins = ansible-deps-cache/python/lib/python3.7/site-packages/ansible_mitogen/plugins/strategy
+nocows = true


### PR DESCRIPTION
Whenever cowsay is intalled, Ansible use it:
```sh
_________________________________________________________
< TASK [../roles/wordpress-instance : Delete sample page] >
 ---------------------------------------------------------
        \   ^__^
         \  (oo)\_______
            (__)\       )\/\
                ||----w |
                ||     ||

```

It's kind of funny the first time, but let's disable it on the long run.

See https://github.com/ansible/ansible/issues/68571