### PR TITLE
fix: Set a fixed version of ewww, the last known to work with WP 6.1

### DIFF
--- a/ansible/roles/wordpress-instance/tasks/plugins.yml
+++ b/ansible/roles/wordpress-instance/tasks/plugins.yml
@@ -432,7 +432,18 @@
     from: https://github.com/epfl-si/wp-plugin-epfl-404
 
 - name: ewww-image-optimizer plugin
-  when: wp_version_lineage is version('5.6', '>=')
+  when: wp_version_lineage is version('6.2', '>=')
+  tags: wp.plugins.ewww
+  wordpress_plugin:
+    name: ewww-image-optimizer
+    state:
+      - symlinked
+      - active
+    from: wordpress.org/plugins
+  register: _plugin_ewww
+
+- name: ewww-image-optimizer plugin
+  when: wp_version_lineage is version('6.2', '<')
   tags: wp.plugins.ewww
   wordpress_plugin:
     name: ewww-image-optimizer
@@ -440,17 +451,6 @@
       - symlinked
       - active
     from: https://downloads.wordpress.org/plugin/ewww-image-optimizer.7.5.0.zip
-  register: _plugin_ewww
-
-- name: ewww-image-optimizer plugin
-  when: wp_version_lineage is version('5.6', '<')
-  tags: wp.plugins.ewww
-  wordpress_plugin:
-    name: ewww-image-optimizer
-    state:
-      - symlinked
-      - active
-    from: https://github.com/nosilver4u/ewww-image-optimizer/archive/refs/tags/v6.2.5.zip
   register: _plugin_ewww
 
 - name: Rebuild ewww-image-optimizer cache

--- a/ansible/roles/wordpress-instance/tasks/plugins.yml
+++ b/ansible/roles/wordpress-instance/tasks/plugins.yml
@@ -439,7 +439,7 @@
     state:
       - symlinked
       - active
-    from: wordpress.org/plugins
+    from: https://downloads.wordpress.org/plugin/ewww-image-optimizer.7.5.0.zip
   register: _plugin_ewww
 
 - name: ewww-image-optimizer plugin


### PR DESCRIPTION
Set version 7.5.0 of EWWW Image Optimizer plugin to stay compatible with WP 6.1  