### PR TITLE
[fix] We don't want a list in the `plugin_restauration_api_password` structure

### DIFF
--- a/ansible/roles/wordpress-instance/vars/plugin-vars.yml
+++ b/ansible/roles/wordpress-instance/vars/plugin-vars.yml
@@ -329,5 +329,5 @@ plugin_restauration_options:
     value: 'https://nutrimenu.ch/nmapi/getMenu'
 
 plugin_restauration_api_password:
-  - name: epfl_restauration_api_password
+    name: epfl_restauration_api_password
     value: '{{ lookup("env_secrets", "wp_plugin_restauration", "RESTAURATION_API_PASSWORD") }}'


### PR DESCRIPTION
... not sure how this could possibly work before ‽