### PR TITLE
[fix] crash in `_get_polylang_languages`

### DIFF
--- a/ansible/roles/wordpress-instance/action_plugins/wordpress_polylang_language.py
+++ b/ansible/roles/wordpress-instance/action_plugins/wordpress_polylang_language.py
@@ -52,12 +52,12 @@ class ActionModule(WordPressActionModule):
         self._run_wp_cli_change("pll lang delete {}".format(language))
 
     def _get_polylang_languages (self):
-        """Returns: A dict of `mo_id`s keyed by language slug."""
+        """Returns: A Set of language slugs."""
 
         def get_moids_by_slug():
-            get_cmd = 'pll lang list --format=json --fields=mo_id,slug'
-            return dict([(lang["slug"], lang["mo_id"])
-                         for lang in self._get_wp_json(get_cmd)])
+            get_cmd = 'pll lang list --format=json --fields=slug'
+            return set(lang["slug"]
+                       for lang in self._get_wp_json(get_cmd))
 
         retval = get_moids_by_slug()
         # mo_id's are created lazily:


### PR DESCRIPTION
Apparently, `wp pll lang list --fields=mo_id` no longer works — Might be related to Polylang 3.4 [dropping support for it](https://polylang.pro/polylang-3-4-eases-the-translation-of-custom-tables/) (under § “Some public properties are removed”)