### PR TITLE
[fix] build on M1 processors

### DIFF
--- a/docker/wp-base/Dockerfile
+++ b/docker/wp-base/Dockerfile
@@ -13,7 +13,7 @@ RUN apt-get -qy update && \
     apt-get clean
 
 # https://github.com/curl/curl/issues/3750
-RUN set -e -x; add-apt-repository ppa:savoury1/backports; \
+RUN set -e -x; add-apt-repository ppa:savoury1/curl34; \
   apt-get -qy update; apt-get -qy install curl
 
 RUN mkdir -p /etc/apt/keyrings


### PR DESCRIPTION
From [the savoury1 PPA](https://launchpad.net/~savoury1), we only require curl; however it appears to also offer git, and to do so differently between processor architectures ☹.