### PR TITLE
[feature] CronJob to refresh the Menu's API's cache

### DIFF
--- a/ansible/roles/wordpress-openshift-namespace/tasks/main.yml
+++ b/ansible/roles/wordpress-openshift-namespace/tasks/main.yml
@@ -139,6 +139,7 @@
         - menu_api
   tags:
     - menu_api
+    - menu_api.cronjob
     - menu_api.is
 
 # A reminder that monitoring pod on wwp is expecting a pushgateway on wwp-infra

--- a/ansible/roles/wordpress-openshift-namespace/tasks/menu-api.yml
+++ b/ansible/roles/wordpress-openshift-namespace/tasks/menu-api.yml
@@ -137,3 +137,30 @@
           targetPort: 3001
       selector:
         deployment-config.name: menu-api-siblings
+
+# CronJob to refresh the Menu's API cache on a regular basis
+- name: "Installing Menu's API refreshing cronjob"
+  openshift:
+    apiVersion: batch/v1beta1
+    kind: CronJob
+    metadata:
+      name: menu-api-refresh-cron
+      namespace: "{{ openshift_namespace }}"
+    spec:
+      schedule: "*/10 * * * *" # Every 10 minutes, mind the CloudFlare cache
+      concurrencyPolicy: "Forbid" # Do not start a new cron if the previous one is still running
+      jobTemplate:
+        spec:
+          template:
+            spec:
+              containers:
+              - name: menu-api-refresh
+                image: "curlimages/curl:8.9.1"
+                imagePullPolicy: IfNotPresent
+                args:
+                  - /bin/sh
+                  - -ec
+                  - 'curl "http://menu-api-siblings:3001/refresh"'
+              restartPolicy: Never
+  tags:
+    - menu_api.cronjob


### PR DESCRIPTION
Use
- `oc get cronjob -n wwp -o wide` to get the cronjob list
- `oc get pods -n wwp -o wide | grep menu-api-refresh` to get the name  of the pod of the last run
- `oc logs menu-api-refresh-cron-1234567890-abcd3 -n wwp` to have the  logs