### PR TITLE
[fix] Pin down the version of the Find My Blocks plugin

### DIFF
--- a/ansible/roles/wordpress-instance/tasks/plugins.yml
+++ b/ansible/roles/wordpress-instance/tasks/plugins.yml
@@ -490,7 +490,7 @@
     state:
       - symlinked
       - active
-    from: wordpress.org/plugins
+    from: https://github.com/morganhvidt/find-my-blocks/archive/refs/tags/v3.5.5.zip
 
 ##################### Category-specific plugins ###########################
 


### PR DESCRIPTION
As in version 4.*, the route `blocks` that we pull requested  (https://github.com/morganhvidt/find-my-blocks/commit/0e7e68414c59d9a5bb3eed74d87b542b80c3c776)  is no longer avalaible. Before changing everything, this is an attempt  to pin down the version in order to make it work.