### PR TITLE
[fix] Pin down the version of the Find My Blocks plugin with local to…

### DIFF
--- a/ansible/roles/wordpress-instance/tasks/plugins.yml
+++ b/ansible/roles/wordpress-instance/tasks/plugins.yml
@@ -490,7 +490,7 @@
     state:
       - symlinked
       - active
-    from: https://github.com/morganhvidt/find-my-blocks/archive/refs/tags/v3.5.5.zip
+    from: "s3://{{ build.s3_assets.bucket_name }}/find-my-blocks-3.5.5.zip"
 
 ##################### Category-specific plugins ###########################
 


### PR DESCRIPTION
Download plugin from https://github.com/morganhvidt/find-my-blocks/archive/refs/tags/v3.5.5.zip not working properly.
We store the plugin localy on s3