### PR TITLE
[feature] `install-plugins-and-themes.py`: auto-skip S3 plugins

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,7 @@ script:
   docker build \
      --build-arg "GITHUB_API_USER=${GITHUB_API_USER}"           \
      --build-arg "GITHUB_API_TOKEN=${GITHUB_API_TOKEN}"         \
-     --build-arg "INSTALL_AUTO_FLAGS=--exclude=wp-media-folder --exclude=wpforms --exclude=wpforms-surveys-polls $wp_base_branch_build_arg" \
+     --build-arg "INSTALL_AUTO_FLAGS=$wp_base_branch_build_arg" \
      -t docker-registry.default.svc:5000/wwp-test/wp-base docker/wp-base
   docker build $mgmt_build_args \
      -t docker-registry.default.svc:5000/wwp-test/mgmt docker/mgmt

--- a/docker/wp-base/install-plugins-and-themes.py
+++ b/docker/wp-base/install-plugins-and-themes.py
@@ -196,8 +196,9 @@ class Plugin(object):
         that.__init__(name, urls, **uncommon_kwargs)
         return that
 
-    def is_to_be_installed(self, flags):
-        return self.name not in flags.exclude
+    def get_skip_reason(self, flags):
+        if self.name in flags.exclude:
+            return "Skipped due to --exclude command-line flag"
 
     @staticmethod
     def subclasses():
@@ -527,7 +528,10 @@ if __name__ == '__main__':
                 progress("Installing mu-plugin {}".format(plugin.name))
                 plugin.install(WP_MU_PLUGINS_INSTALL_DIR, rename_like_self=False)
         for plugin in manifest.plugins():
-            if plugin.is_to_be_installed(flags):
+            skip_reason = plugin.get_skip_reason(flags)
+            if skip_reason:
+                progress("Skipping plugin {}: {}".format(plugin.name, skip_reason))
+            else:
                 progress("Installing plugin {}".format(plugin.name))
                 plugin.install(WP_PLUGINS_INSTALL_DIR)
         for theme in Themes.all():

--- a/docker/wp-base/install-plugins-and-themes.py
+++ b/docker/wp-base/install-plugins-and-themes.py
@@ -196,6 +196,9 @@ class Plugin(object):
         that.__init__(name, urls, **uncommon_kwargs)
         return that
 
+    def is_to_be_installed(self, flags):
+        return self.name not in flags.exclude
+
     @staticmethod
     def subclasses():
         return (S3Plugin, ZipPlugin, GitHubPlugin, WordpressOfficialPlugin)
@@ -524,7 +527,7 @@ if __name__ == '__main__':
                 progress("Installing mu-plugin {}".format(plugin.name))
                 plugin.install(WP_MU_PLUGINS_INSTALL_DIR, rename_like_self=False)
         for plugin in manifest.plugins():
-            if plugin.name not in flags.exclude:
+            if plugin.is_to_be_installed(flags):
                 progress("Installing plugin {}".format(plugin.name))
                 plugin.install(WP_PLUGINS_INSTALL_DIR)
         for theme in Themes.all():

--- a/docker/wp-base/install-plugins-and-themes.py
+++ b/docker/wp-base/install-plugins-and-themes.py
@@ -302,8 +302,8 @@ class S3Plugin(Plugin):
     client = None
 
     @classmethod
-    def set_client(cls, client):
-        cls.client = client
+    def configure(cls, flags):
+        cls.client = flags.s3
 
     def __init__(self, name, urls, **uncommon_kwargs):
         super(S3Plugin, self).__init__(name, urls, **uncommon_kwargs)
@@ -517,7 +517,7 @@ if __name__ == '__main__':
     flags = Flags()
 
     if flags.auto:
-        S3Plugin.set_client(flags.s3)
+        S3Plugin.configure(flags)
 
         manifest = WpOpsPlugins(flags.manifest_url, flags.wp_version)
         for d in (WP_PLUGINS_INSTALL_DIR, WP_MU_PLUGINS_INSTALL_DIR):

--- a/docker/wp-base/install-plugins-and-themes.py
+++ b/docker/wp-base/install-plugins-and-themes.py
@@ -198,7 +198,7 @@ class Plugin(object):
 
     def get_skip_reason(self, flags):
         if self.name in flags.exclude:
-            return "Skipped due to --exclude command-line flag"
+            return "as requested with --exclude command-line flag"
 
     @staticmethod
     def subclasses():
@@ -304,6 +304,12 @@ class S3Plugin(Plugin):
     @classmethod
     def configure(cls, flags):
         cls.client = flags.s3
+
+    def get_skip_reason(self, flags):
+        if not self.client:
+            return "S3 credentials missing on the command line"
+        else:
+            return super(S3Plugin, self).get_skip_reason(flags)
 
     def __init__(self, name, urls, **uncommon_kwargs):
         super(S3Plugin, self).__init__(name, urls, **uncommon_kwargs)

--- a/docker/wp-base/install-plugins-and-themes.py
+++ b/docker/wp-base/install-plugins-and-themes.py
@@ -61,12 +61,6 @@ Usage:
     subdirectory), or it can be the string "wordpress.org/plugins",
     meaning that the plug-in named <name> shall be downloaded
     from the WordPress plugin repository.
-
-Options:
-
-  --exclude <plugin-name>
-
-    Exclude that plugin when in "auto" mode
 """ % AUTO_MANIFEST_URL)
 
 


### PR DESCRIPTION
Some of the WordPress plugins that we use are hosted on EPFL's S3-compatible on-premise server, for various reasons (e.g. the plugin was discontinued upstream, or it was paid-for and its source code should not be made public). For cases in which S3 access and/or credentials are unavailable (e.g. the Travis build), we used to have a blacklist mechanism with `install-plugins-and-themes.py`'s `--exclude` flag.

This PR makes it so that omitting the `--s3-endpoint-url` flag  implicitly `--exclude`s any and all plugins hosted on S3.
