### PR TITLE
[fix] the build on M1

### DIFF
--- a/docker/httpd/Dockerfile
+++ b/docker/httpd/Dockerfile
@@ -31,7 +31,7 @@ RUN apt-get -qy update && apt-get -qy install --no-install-recommends \
     libio-all-lwp-perl \
     libreadonly-perl \
     libsecret-1-0 \
-    libgsasl18 \
+    `case "$(arch)" in x86_64) echo libgsasl18 ;; *) echo libgsasl7 ;; esac` \
   && \
     apt-get -qy autoremove && \
     apt-get clean

--- a/docker/wp-base/Dockerfile
+++ b/docker/wp-base/Dockerfile
@@ -16,6 +16,12 @@ RUN apt-get -qy update && \
 RUN set -e -x; add-apt-repository ppa:savoury1/backports; \
   apt-get -qy update; apt-get -qy install curl
 
+RUN if [ `arch` = "aarch64" ]; then \
+     ( echo "Package: git-man"; \
+       echo "Pin: release o=LP-PPA-savoury1-backports";  \
+       echo "Pin-Priority: -1" ) > /etc/apt/preferences; \
+    fi
+
 RUN mkdir -p /etc/apt/keyrings
 RUN curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
 RUN echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODE_VERSION_MAJOR.x nodistro main" > /etc/apt/sources.list.d/nodesource.list


### PR DESCRIPTION
This is take 2 of #553 which was [reverted](https://github.com/epfl-si/wp-ops/pull/553). This time around, all the tweaks are guarded so that they cannot possibly interfere with the `x86_64` architecture.

There are various not-so-subtle variations on `ppa:savoury1/backports` between the `x86_64` and `aarch64` architecture; for instance, it only carries `git` for the former... yet it has `git-man` for both  🤦
