### PR TITLE
[fix] Minimum of 3 caracters

### DIFF
--- a/kopf-operator/WordPressSite-crd.yaml
+++ b/kopf-operator/WordPressSite-crd.yaml
@@ -66,11 +66,11 @@ spec:
                   title:
                     description: WordpressSite's title
                     type: string
-                    pattern: ^[a-zA-Z]{3}(.*)$
+                    pattern: ^[\w -_.]{3,}$
                   tagline:
                     description: WordpressSite's tagline
                     type: string
-                    pattern: ^[a-zA-Z]{3}(.*)$
+                    pattern: ^[\w -_.]{3,}$
                   theme:
                     description: WordpressSite's theme
                     type: string


### PR DESCRIPTION
The previous regex wanted a full word of 3 characters, which wasn't  always convenient.