### PR TITLE
[feature] Set option for VSMD

### DIFF
--- a/ansible/roles/wordpress-instance/tasks/main.yml
+++ b/ansible/roles/wordpress-instance/tasks/main.yml
@@ -149,29 +149,30 @@
   tags:
     - wp
     - wp.plugins
-    - wp.plugins.wp_media_folder_options
-    - wp.plugins.epfl-coming-soon
-    - wp.plugins.coming-soon
-    - wp.plugins.epfl-coming-soon
-    - wp.plugins.unknown
-    - wp.plugins.polylang
-    - wp.plugins.wpforms
-    - wp.plugins.wpforms-surveys-polls
     - wp.plugins.cachecontrol
-    - wp.plugins.payonline
+    - wp.plugins.coming-soon
+    - wp.plugins.diploma-verification
+    - wp.plugins.epfl-coming-soon
+    - wp.plugins.epfl-coming-soon
     - wp.plugins.ewww
-    - wp.plugins.ewww.optimize
     - wp.plugins.ewww.configure
+    - wp.plugins.ewww.optimize
     - wp.plugins.intranet
     - wp.plugins.intranet.htaccess
-    - wp.plugins.pdf
-    - wp.plugins.restauration.options
     - wp.plugins.mu
-    - wp.plugins.mu.social-graph
     - wp.plugins.mu.last-changes
-    - wp.plugins.wp-gutenberg
-    - wp.plugins.diploma-verification
+    - wp.plugins.mu.social-graph
     - wp.plugins.partner-universities
+    - wp.plugins.payonline
+    - wp.plugins.pdf
+    - wp.plugins.polylang
+    - wp.plugins.restauration.options
+    - wp.plugins.unknown
+    - wp.plugins.vsmd
+    - wp.plugins.wp_media_folder_options
+    - wp.plugins.wp-gutenberg
+    - wp.plugins.wpforms
+    - wp.plugins.wpforms-surveys-polls
     # OBSOLETE aliases:
     - plugins
     - plugins.wp_media_folder_options

--- a/ansible/roles/wordpress-instance/tasks/plugins.yml
+++ b/ansible/roles/wordpress-instance/tasks/plugins.yml
@@ -424,6 +424,14 @@
       - symlinked
       - active
     from: wordpress.org/plugins
+  tags:
+    - wp.plugins.vsmd
+
+- name: very-simple-meta-description options
+  wordpress_option: "{{ item }}"
+  with_items: "{{ plugin_vsmd_options }}"
+  tags:
+    - wp.plugins.vsmd
 
 - name: epfl-404 plugin
   wordpress_plugin:

--- a/ansible/roles/wordpress-instance/vars/plugin-vars.yml
+++ b/ansible/roles/wordpress-instance/vars/plugin-vars.yml
@@ -331,3 +331,9 @@ plugin_restauration_options:
 plugin_restauration_api_password:
     name: epfl_restauration_api_password
     value: '{{ lookup("env_secrets", "wp_plugin_restauration", "RESTAURATION_API_PASSWORD") }}'
+
+# Very Simple Meta Description (VSMD)
+plugin_vsmd_options:
+  # Set the use post and page's excerpt as meta description.
+  - name: vsmd-setting-2
+    value: 'yes'


### PR DESCRIPTION
The Very Simple Meta Description plugin allows users to set meta-data  for the site (`<meta name="description"...`). One of its options allow  to use pages and posts excerpts as meta description, but this option is  off by default.

This commit:
- Set the `vsmd-setting-2` to yes in the wp-options table (the setting  we are interested in)
- Add the tag `-t wp.plugins.vsmd` to wpsible
- Sort the tags for the plugins in alphabetical order

Also, see [WEBEVOL-252](https://epfl-webvolution.atlassian.net/browse/WEBEVOL-252).