### PR TITLE
[fix] WPN-79

### DIFF
--- a/docker/nginx/Dockerfile
+++ b/docker/nginx/Dockerfile
@@ -23,6 +23,8 @@ RUN sed -i 's|^;log_level = .*|log_level = notice|' /etc/php/${PHP_VERSION}/fpm/
 RUN sed -i 's|^;log_limit = .*|log_limit = 4096|' /etc/php/${PHP_VERSION}/fpm/php-fpm.conf
 RUN sed -i 's|^error_log = .*|error_log = /proc/self/fd/2|' /etc/php/${PHP_VERSION}/fpm/php-fpm.conf
 
+COPY php.ini /etc/php/${PHP_VERSION}/conf.d/local.ini
+
 RUN sed -i 's|^listen = .*|listen = /run/php-fpm.sock|' /etc/php/${PHP_VERSION}/fpm/pool.d/www.conf
 RUN sed -i 's|;access.log = .*|access.log = /dev/null|' /etc/php/${PHP_VERSION}/fpm/pool.d/www.conf
 RUN echo 'catch_workers_output = yes' >> /etc/php/${PHP_VERSION}/fpm/pool.d/www.conf

--- a/docker/nginx/php.ini
+++ b/docker/nginx/php.ini
@@ -1,0 +1,3 @@
+[php]
+;; A `realpath(3)` cache, really. What is this, Windows®?
+realpath_cache_size = 0


### PR DESCRIPTION
Dear PHP, please be hereby informed that the kernel has a `realpath()` cache too. Which actually does work i.e. it is kept coherent when Kubernetes updates its Rube Goldberg symlinks.