### PR TITLE
[workaround] In OpenShift 4.15, we need `imagePuilSecrets` as well

### DIFF
--- a/ansible/roles/wordpress-openshift-namespace/tasks/buildconfig-prerequisites.yml
+++ b/ansible/roles/wordpress-openshift-namespace/tasks/buildconfig-prerequisites.yml
@@ -20,3 +20,8 @@
         namespace: "{{ openshift_namespace }}"
       secrets:
         - name: builder-pull-secret
+      # This is not supposed to be required (it worked without in
+      # OpenShift 4.14); but see
+      # https://access.redhat.com/solutions/7098226
+      imagePullSecrets:
+      - name: builder-pull-secret


### PR DESCRIPTION
I admit I didn't read https://access.redhat.com/solutions/7098226 all the way through. I stopped at the “Resolution” § and translated it into Ansible.