### PR TITLE
[fix] Do the RBAC on RKE2 namespaces only

### DIFF
--- a/ansible/roles/wordpress-namespace/tasks/main.yml
+++ b/ansible/roles/wordpress-namespace/tasks/main.yml
@@ -23,6 +23,11 @@
       tags:
         - wp
         - wp.web
+      vars:
+        # We want to manage RBAC in RKE2 clusters only — OpenShifts
+        # (and OKDs) use OLM as the RBAC vehicle instead:
+        _rbac_managed: >-
+          {{ "rke2_namespaces" in group_names }}
   tags:
     - wp
     - wp.web

--- a/ansible/roles/wordpress-namespace/tasks/nginx.yml
+++ b/ansible/roles/wordpress-namespace/tasks/nginx.yml
@@ -1,4 +1,5 @@
-- name: ServiceAccount/wp-nginx
+- when: _rbac_managed   # See this variable in main.yml
+  name: ServiceAccount/wp-nginx
   kubernetes.core.k8s:
     state: present
     definition:
@@ -9,8 +10,9 @@
         namespace: "{{ inventory_namespace }}"
       automountServiceAccountToken: false
 
-# TODO: move all of this to the controller. WPN-218
-- name: RoleBinding/wp-nginx
+
+- when: _rbac_managed
+  name: RoleBinding/wp-nginx
   kubernetes.core.k8s:
     state: present
     definition:
@@ -29,7 +31,8 @@
         name: wp-nginx
 
 
-- name: Role/wp-nginx
+- when: _rbac_managed
+  name: Role/wp-nginx
   kubernetes.core.k8s:
     state: present
     definition:
@@ -76,7 +79,8 @@
           verbs: ['get', 'watch']
 
 
-- name: ClusterRoleBinding/wp-nginx
+- when: _rbac_managed
+  name: ClusterRoleBinding/wp-nginx
   kubernetes.core.k8s:
     state: present
     definition:
@@ -95,7 +99,8 @@
         name: wp-nginx
 
 
-- name: ClusterRole/wp-nginx
+- when: _rbac_managed
+  name: ClusterRole/wp-nginx
   kubernetes.core.k8s:
     state: present
     definition:


### PR DESCRIPTION
Fixes [WPN-218](https://go.epfl.ch/WPN-218) in part (the other part being [already in `epfl-si/wp-operator`](https://github.com/epfl-si/wp-operator/commit/7fe22f63588abcb981f7a16f06901f1332b0a3a7))

On an EPFL “official” OpenShift instance with namespace-as-a-service (that we don't have cluster-admin on), only the [OLM controller](https://github.com/epfl-si/wp-operator/tree/main/olm) can set up RBAC on our behalf. On the other hand, Rancher doesn't have OLM, and thus we need to manage RBAC through Ansible there.

- Introduce `_rbac_managed` Boolean variable to discern these case
- Pepper `ansible/roles/wordpress-namespace/tasks/nginx.yml` with `when: _rbac_managed` constructs for all things RBAC

[WPN-218]: https://erpdev.atlassian.net/browse/WPN-218?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ