### PR TITLE
[fix] Do our PVs / PVCs “the ITOP-SDDC way”

### DIFF
--- a/ansible/roles/wordpress-namespace/tasks/storage.yml
+++ b/ansible/roles/wordpress-namespace/tasks/storage.yml
@@ -17,6 +17,7 @@
           # we want to pretend it costs almost nothing:
           storage: 1Gi
         volumeMode: Filesystem
+        storageClassName: ""
         nfs:
           server: nas-app-ma-nfs1.epfl.ch
           path: /svc0041_si_openshift_app_wwp_test_app/wp-data
@@ -40,6 +41,7 @@
         resources:
           requests:
             storage: 1Gi
+        storageClassName: ""
 
 # During the transition period, we can read from the old volumes:
 
@@ -58,6 +60,7 @@
         capacity:
           storage: 1Gi
         volumeMode: Filesystem
+        storageClassName: ""
         nfs:
           server: nas-app-ma-nfs1.epfl.ch
           path: /si_openshift_app_wwp_app/wordpress
@@ -82,3 +85,4 @@
         resources:
           requests:
             storage: 1Gi
+        storageClassName: ""

--- a/ansible/roles/wordpress-namespace/tasks/storage.yml
+++ b/ansible/roles/wordpress-namespace/tasks/storage.yml
@@ -12,12 +12,18 @@
         accessModes:
         - ReadWriteMany
         capacity:
-          storage: 500Gi
+          # This counts towards our OpenShift quota (despite the
+          # metering happening on different hardware altogether), so
+          # we want to pretend it costs almost nothing:
+          storage: 1Gi
         volumeMode: Filesystem
-        storageClassName: nfs-client
         nfs:
           server: nas-app-ma-nfs1.epfl.ch
           path: /svc0041_si_openshift_app_wwp_test_app/wp-data
+        claimRef:
+          kind: PersistentVolumeClaim
+          namespace: "{{ inventory_namespace }}"
+          name: wp-data
 
 - name: PersistentVolumeClaim/wp-data
   kubernetes.core.k8s:
@@ -33,9 +39,7 @@
           - ReadWriteMany
         resources:
           requests:
-            storage: 500Gi
-        storageClassName: nfs-client
-        volumeName: wp-data
+            storage: 1Gi
 
 # During the transition period, we can read from the old volumes:
 
@@ -52,13 +56,16 @@
         accessModes:
         - ReadOnlyMany
         capacity:
-          storage: 500Gi
+          storage: 1Gi
         volumeMode: Filesystem
-        storageClassName: nfs-client
         nfs:
           server: nas-app-ma-nfs1.epfl.ch
           path: /si_openshift_app_wwp_app/wordpress
           readOnly: true
+        claimRef:
+          kind: PersistentVolumeClaim
+          namespace: "{{ inventory_namespace }}"
+          name: wp-data-ro-openshift3
 
 - name: PersistentVolumeClaim/wp-data-ro-openshift3
   kubernetes.core.k8s:
@@ -74,6 +81,4 @@
           - ReadOnlyMany
         resources:
           requests:
-            storage: 500Gi
-        storageClassName: nfs-client
-        volumeName: wp-data-ro-openshift3
+            storage: 1Gi


### PR DESCRIPTION
- Downplay the actual storage use, so as not to upset quota computations 😉 (the real metering of this resource happens in the NAS, rather than in OpenShift)
- Have the PV point to the PVC, rather than the other way round. This way, it is not possible to “steal” our PV between the time our ticket is acted upon, and the time we get around to running `wpsible -t wp.storage` again
- Set the shared `storageClassName` to the empty string