### PR TITLE
[feature] Define the StorageClass (no more `mariadb-min`)

### DIFF
--- a/ansible/roles/wordpress-namespace/tasks/mariadb.yml
+++ b/ansible/roles/wordpress-namespace/tasks/mariadb.yml
@@ -1,19 +1,30 @@
 - tags: always
   include_vars:
-    file : "backup-secrets-{{ inventory_deployment_stage }}.yml"
+    file : "{{ item }}"
+  with_items: 
+    - mariadb-vars.yml
+    - "backup-secrets-{{ inventory_deployment_stage }}.yml"
 
-- name: "`MariaDB/mariadb-min`"
+- name: "MariaDB/{{ mariadb_name }} with StorageClass {{ storage_class_to_use }}"
   kubernetes.core.k8s:
     state: present
     definition:
       apiVersion: k8s.mariadb.com/v1alpha1
       kind: MariaDB
       metadata:
-        name: mariadb-min
+        name: "{{ mariadb_name }}"
         namespace: "{{ inventory_namespace }}"
       spec:
         storage:
-          size: 2G
+          size: 100Gi
+          storageClassName: "{{ storage_class_to_use }}"
+          volumeClaimTemplate:
+            accessModes:
+              - ReadWriteOnce
+            resources:
+              requests:
+                storage: 100Gi
+            storageClassName: "{{ storage_class_to_use }}"
         rootPasswordSecretKeyRef:
           name: mariadb
           key: root-password
@@ -21,18 +32,18 @@
         metrics:
           enabled: true
 
-- name: "MariaDB cron job for backups"
+- name: "Backup/{{ mariadb_name }} (Backups scheduling)"
   kubernetes.core.k8s:
     state: present
     definition:
       apiVersion: k8s.mariadb.com/v1alpha1
       kind: Backup
       metadata:
+        name: "{{ mariadb_name }}"
         namespace: "{{ inventory_namespace }}"
-        name: backup-mariadb
       spec:
         mariaDbRef:
-          name: mariadb-min
+          name: "{{ mariadb_name }}"
         schedule:
           cron: "0 3 */1 * *"
           suspend: false

--- a/ansible/roles/wordpress-namespace/tasks/mariadb.yml
+++ b/ansible/roles/wordpress-namespace/tasks/mariadb.yml
@@ -45,7 +45,7 @@
         mariaDbRef:
           name: "{{ mariadb_name }}"
         schedule:
-          cron: "0 3 */1 * *"
+          cron: "0 1 * * *"
           suspend: false
         storage:
           s3:

--- a/ansible/roles/wordpress-namespace/tasks/nginx.yml
+++ b/ansible/roles/wordpress-namespace/tasks/nginx.yml
@@ -238,7 +238,7 @@
                 emptyDir: {}
               - name: wp-data
                 persistentVolumeClaim:
-                  claimName: wp-data
+                  claimName: wordpress-data
               # Uncomment the next three lines to embug the nginx configuration
               # (see also similar comments elsewhere in the file):
               # - name: wp-nginx

--- a/ansible/roles/wordpress-namespace/tasks/nginx.yml
+++ b/ansible/roles/wordpress-namespace/tasks/nginx.yml
@@ -183,11 +183,15 @@
                   - --https-port=8443
                 resources:
                   limits:
-                    cpu: '1'
+                    cpu: 750m
                     memory: 1Gi
                   requests:
-                    cpu: 500m
-                    memory: 512Mi
+                    cpu: >-
+                      {{ "1" if inventory_namespace == "svc0041p-wordpress"
+                      else "20m" }}
+                    memory: >-
+                      {{ "1Gi" if inventory_namespace == "svc0041p-wordpress"
+                      else "256Mi" }}
                 ports:
                   - containerPort: 8000
                     protocol: TCP
@@ -220,11 +224,15 @@
                 image: quay-its.epfl.ch/svc0041/wp-php:2024-012
                 resources:
                   limits:
-                    cpu: '1'
+                    cpu: 750m
                     memory: 1Gi
                   requests:
-                    cpu: 500m
-                    memory: 512Mi
+                    cpu: >-
+                      {{ "1" if inventory_namespace == "svc0041p-wordpress"
+                      else "20m" }}
+                    memory: >-
+                      {{ "1Gi" if inventory_namespace == "svc0041p-wordpress"
+                      else "256Mi" }}
                 volumeMounts:
                   - name: wp-data
                     mountPath: /wp-data/
@@ -310,4 +318,3 @@
                       name: wp-nginx
                       port:
                         number: 80
-


### PR DESCRIPTION
[feature] Define the StorageClass (no more `mariadb-min`)

- Without specifying it, the default StorageClass is used: we need to use "our" StorageClass defined with the `NfsSubdirProvisioner`.
- Use a variable for the `kind: MariaDB` object's name
- Add a `mariadb-vars.yaml` for MariaDB specific vars
