### PR TITLE
[feature](WPN-271) Remove wp-admin's symlink and run backups

### DIFF
--- a/ansible/roles/wordpress-instance/tasks/break-wp-admin-symlink.yml
+++ b/ansible/roles/wordpress-instance/tasks/break-wp-admin-symlink.yml
@@ -1,0 +1,4 @@
+- name: Remove symlink wp-admin
+  ansible.builtin.file:
+    path: "{{ wp_dir }}/wp-admin"
+    state: absent

--- a/ansible/roles/wordpress-instance/tasks/main.yml
+++ b/ansible/roles/wordpress-instance/tasks/main.yml
@@ -39,6 +39,20 @@
 # be guarded by a suitable `when:` clause, which ensures that we do
 # nothing if the user already took the matters in their own hands.
 
+- name: Break symlink wp-admin
+  tags:
+    - never  # That is, skip unless "-t wp.wipe" or "-t wp.backup" is
+             # passed on the command line
+    - wp.break-wp-admin-symlink
+    - wp.mig_os4
+  include_tasks:
+    file: "break-wp-admin-symlink.yml"
+    apply:
+      # Tags don't auto-inherit with `include_tasks`:
+      tags:
+        - wp.break-wp-admin-symlink
+        - wp.mig_os4
+
 - name: Backup
   when: >-
     (wp_do_backup | default(True) | bool)
@@ -49,6 +63,7 @@
              # passed on the command line
     - wp.wipe
     - wp.backup
+    - wp.mig_os4
   include_tasks:
     file: "backup.yml"
     apply:
@@ -56,6 +71,7 @@
       tags:
         - wp.wipe
         - wp.backup
+        - wp.mig_os4
 
 - name: Wipe
   import_tasks: "wipe.yml"


### PR DESCRIPTION
**Break symlink wp-admin and backup on s3**

For migration to s4, remove symlink wp-admin to avoid users to edit on wp-admin, and backup afterwards. 

Tags:
- `wp.break-wp-admin-symlink` → remove symlink wp-admin
- `wp.mig_os4` → remove symlink wp-admin and run backups on s3

Example: remove symlink wp-admin of [hostname] and backups on s3
`./wpsible -l [hostname] -t wp.mig_os4 `