### PR TITLE
[feature] MariaDB backups

### DIFF
--- a/ansible/roles/wordpress-namespace/tasks/mariadb.yml
+++ b/ansible/roles/wordpress-namespace/tasks/mariadb.yml
@@ -54,6 +54,8 @@
           requests:
             cpu: 50m
             memory: 64Mi
+        # This is the default:
+        maxRetention: 720h
         storage:
           s3:
             bucket: "{{ s3_bucket }}"

--- a/ansible/roles/wordpress-namespace/tasks/mariadb.yml
+++ b/ansible/roles/wordpress-namespace/tasks/mariadb.yml
@@ -47,6 +47,14 @@
         schedule:
           cron: "0 1 * * *"
           suspend: false
+        args:
+          # Note: our volume comes from a NetApp share that have the
+          #       snapshoting acitvated. It creates a `.snapshot` folders in
+          #       every directories, resulting in this error:
+          #         `mariadb-dump: Got error: 1102: "Incorrect database name 
+          #           '#mysql50#.snapshot'" when selecting the database`
+          #      The following line ignore the backups from theses folders.
+          - '--ignore-database=#mysql50#.snapshot'
         resources:
           limits:
             cpu: 300m

--- a/ansible/roles/wordpress-namespace/tasks/mariadb.yml
+++ b/ansible/roles/wordpress-namespace/tasks/mariadb.yml
@@ -47,6 +47,13 @@
         schedule:
           cron: "0 1 * * *"
           suspend: false
+        resources:
+          limits:
+            cpu: 300m
+            memory: 512Mi
+          requests:
+            cpu: 50m
+            memory: 64Mi
         storage:
           s3:
             bucket: "{{ s3_bucket }}"


### PR DESCRIPTION
- `--ignore-database=#mysql50#.snapshot`
- Explicit 720h retention
- Limits for resoures