### PR TITLE
[feature] Multiple MariaDBs

### DIFF
--- a/ansible/roles/wordpress-namespace/tasks/mariadb.yml
+++ b/ansible/roles/wordpress-namespace/tasks/mariadb.yml
@@ -54,6 +54,8 @@
           requests:
             cpu: 50m
             memory: 64Mi
+        # This is the default:
+        maxRetention: 720h
         storage:
           s3:
             bucket: "{{ s3_bucket }}"

--- a/ansible/roles/wordpress-namespace/tasks/mariadb.yml
+++ b/ansible/roles/wordpress-namespace/tasks/mariadb.yml
@@ -47,6 +47,14 @@
         schedule:
           cron: "0 1 * * *"
           suspend: false
+        args:
+          # Note: our volume comes from a NetApp share that have the
+          #       snapshoting acitvated. It creates a `.snapshot` folders in
+          #       every directories, resulting in this error:
+          #         `mariadb-dump: Got error: 1102: "Incorrect database name 
+          #           '#mysql50#.snapshot'" when selecting the database`
+          #       The following line ignore the backups from these folders.
+          - '--ignore-database=#mysql50#.snapshot'
         resources:
           limits:
             cpu: 300m

--- a/ansible/roles/wordpress-namespace/tasks/mariadb.yml
+++ b/ansible/roles/wordpress-namespace/tasks/mariadb.yml
@@ -47,6 +47,13 @@
         schedule:
           cron: "0 1 * * *"
           suspend: false
+        resources:
+          limits:
+            cpu: 300m
+            memory: 512Mi
+          requests:
+            cpu: 50m
+            memory: 64Mi
         storage:
           s3:
             bucket: "{{ s3_bucket }}"

--- a/ansible/roles/wordpress-namespace/tasks/mariadb.yml
+++ b/ansible/roles/wordpress-namespace/tasks/mariadb.yml
@@ -5,14 +5,17 @@
     - mariadb-vars.yml
     - "backup-secrets-{{ inventory_deployment_stage }}.yml"
 
-- name: "MariaDB/{{ mariadb_name }} with StorageClass {{ storage_class_to_use }}"
+- name: "MariaDB/{{ mariadb_name }}-0x with StorageClass {{ storage_class_to_use }}"
+  with_sequence: >-
+    {{ "1-" + number_of_mariadb|string if inventory_namespace == "svc0041p-wordpress"
+        else "1-2" }}
   kubernetes.core.k8s:
     state: present
     definition:
       apiVersion: k8s.mariadb.com/v1alpha1
       kind: MariaDB
       metadata:
-        name: "{{ mariadb_name }}"
+        name: "{{ mariadb_name }}-{{ '%02d' | format(item|int) }}"
         namespace: "{{ inventory_namespace }}"
       spec:
         storage:
@@ -33,19 +36,22 @@
           enabled: true
 
 - name: "Backup/{{ mariadb_name }} (Backups scheduling)"
+  with_sequence: >-
+    {{ "1-" + number_of_mariadb|string if inventory_namespace == "svc0041p-wordpress"
+        else "1-2" }}
   kubernetes.core.k8s:
     state: present
     definition:
       apiVersion: k8s.mariadb.com/v1alpha1
       kind: Backup
       metadata:
-        name: "{{ mariadb_name }}"
+        name: "{{ mariadb_name }}-{{ '%02d' | format(item|int) }}"
         namespace: "{{ inventory_namespace }}"
       spec:
         mariaDbRef:
           name: "{{ mariadb_name }}"
         schedule:
-          cron: "0 1 * * *"
+          cron: "0 {{ item|int }} * * *"
           suspend: false
         args:
           # Note: our volume comes from a NetApp share that have the

--- a/ansible/roles/wordpress-namespace/vars/mariadb-vars.yml
+++ b/ansible/roles/wordpress-namespace/vars/mariadb-vars.yml
@@ -1,3 +1,4 @@
 ---
 mariadb_name: mariadb
 storage_class_to_use: wordpress-nfs-db
+number_of_mariadb: 5


### PR DESCRIPTION
This will deploy the number of MariaDBs (servers) defined by the
variable `number_of_mariadb` in the `svc0041p-wordpress` namespace, but
only 2 in other namespaces. This is hard-coded in the `with_sequence`
Ansible parameter.

This also create the Backups objects, which are set to be ran at
the hour defined by identifier used for the naming of the MariaDB.
`mariadb-01`'s backups will be ran at 1, `mariadb-02`'s backups will be
ran at 2, etc. This is a temporary and very basic way to unsure that the
backups will not use all resources at once. 