### PR TITLE
[feature] Use newly-created `WPN` branch of `epfl-si/wp-mu-plugins`

### DIFF
--- a/ansible/roles/wordpress-namespace/tasks/nginx.yml
+++ b/ansible/roles/wordpress-namespace/tasks/nginx.yml
@@ -171,7 +171,7 @@
             automountServiceAccountToken: false
             containers:
               - name: nginx
-                image: quay-its.epfl.ch/svc0041/wp-nginx:2025-008
+                image: quay-its.epfl.ch/svc0041/wp-nginx:2025-011
                 command:
                   - /nginx-ingress-controller
                   - --disable-leader-election
@@ -220,7 +220,7 @@
                         apiVersion: v1
                         fieldPath: metadata.namespace
               - name: php
-                image: quay-its.epfl.ch/svc0041/wp-php:2025-008
+                image: quay-its.epfl.ch/svc0041/wp-php:2025-011
                 resources:
                   limits:
                     cpu: '{{ _request_cpu }}'

--- a/docker/wp-base/install-wordpress.sh
+++ b/docker/wp-base/install-wordpress.sh
@@ -135,7 +135,7 @@ install_mu_plugins () {
     (
         cd $targetdir/wp-content
         rm -rf mu-plugins
-        git clone -b feature/upgradePHPAndWordpressVersion https://github.com/epfl-si/wp-mu-plugins mu-plugins
+        git clone -b WPN https://github.com/epfl-si/wp-mu-plugins mu-plugins
     )
 }
 


### PR DESCRIPTION
Attention everyone: just like in `wp-ops` itself, changes to the mu-plugins must now be merged into WPN to appear in OpenShift 4.
