### PR TITLE
[feature](WPN-239) Add wp-nginx pods affinity rules

### DIFF
--- a/ansible/roles/wordpress-namespace/tasks/nginx.yml
+++ b/ansible/roles/wordpress-namespace/tasks/nginx.yml
@@ -167,6 +167,13 @@
             labels:
               app: wp-nginx
           spec:
+            affinity:
+              podAntiAffinity:
+                requiredDuringSchedulingIgnoredDuringExecution:
+                  - labelSelector:
+                      matchLabels:
+                        app: wp-nginx
+                    topologyKey: kubernetes.io/hostname
             serviceAccountName: wp-nginx
             automountServiceAccountToken: false
             containers:

--- a/ansible/roles/wordpress-namespace/tasks/nginx.yml
+++ b/ansible/roles/wordpress-namespace/tasks/nginx.yml
@@ -174,6 +174,13 @@
                       matchLabels:
                         app: wp-nginx
                     topologyKey: kubernetes.io/hostname
+                preferredDuringSchedulingIgnoredDuringExecution:
+                  - weight: 100
+                    podAffinityTerm:
+                      labelSelector:
+                        matchLabels:
+                          app: wp-nginx
+                      topologyKey: topology.kubernetes.io/zone
             serviceAccountName: wp-nginx
             automountServiceAccountToken: false
             containers:


### PR DESCRIPTION
https://erpdev.atlassian.net/browse/WPN-239

Create pod anti-affinity rules to (at a minimum) prevent both pods from running on the same node.
Additionally, enforce that they run in different data centers.