### PR TITLE
[feature](WPN-240) Add PodDisruptionBudget for wp-nginx

### DIFF
--- a/ansible/roles/wordpress-namespace/tasks/nginx.yml
+++ b/ansible/roles/wordpress-namespace/tasks/nginx.yml
@@ -285,6 +285,21 @@
     _request_cpu_de_minimis: "20m"
     _request_ram_de_minimis: "256Mi"
 
+- name: PodDisruptionBudget/wp-nginx
+  kubernetes.core.k8s:
+    state: present
+    definition:
+      apiVersion: policy/v1
+      kind: PodDisruptionBudget
+      metadata:
+        name: wp-nginx
+        namespace: "{{ inventory_namespace }}"
+      spec:
+        minAvailable: 1
+        selector:
+          matchLabels:
+            app: wp-nginx
+
 - name: PodMonitor/wp-nginx
   kubernetes.core.k8s:
     state: present


### PR DESCRIPTION
https://erpdev.atlassian.net/browse/WPN-240

Create a PodDisruptionBudget to prevent OpenShift from scheduling its update by terminating both pods at the same time.