### PR TITLE
[fix] Pin theme to last-known working version in prod

### DIFF
--- a/docker/wp-base/install-wordpress.sh
+++ b/docker/wp-base/install-wordpress.sh
@@ -127,7 +127,7 @@ install_themes () {
     (
         cd $targetdir/wp-content
         rm -rf themes
-        git clone -b  feature/upgradePHPAndWordpressVersion https://github.com/epfl-si/wp-theme-2018 themes
+        git clone -b WPN https://github.com/epfl-si/wp-theme-2018 themes
     )
 }
 


### PR DESCRIPTION
I carefully cut the [`WPN` branch in `wp-theme-2018`](https://github.com/epfl-si/wp-theme-2018/tree/WPN) so that there is no difference with the current content of `/wp/6/wp-content/themes/wp-theme-2018/` of version  2025-011 [in Quay](https://quay-its.epfl.ch/repository/svc0041/wp-nginx?tab=tags).