### PR TITLE
[fix] Block auto-updates and other self-modifying PHP code

### DIFF
--- a/ansible/roles/wordpress-namespace/tasks/nginx.yml
+++ b/ansible/roles/wordpress-namespace/tasks/nginx.yml
@@ -185,7 +185,7 @@
             automountServiceAccountToken: false
             containers:
               - name: nginx
-                image: quay-its.epfl.ch/svc0041/wp-nginx:2025-016
+                image: quay-its.epfl.ch/svc0041/wp-nginx:2025-017
                 command:
                   - /nginx-ingress-controller
                   - --disable-leader-election
@@ -234,7 +234,7 @@
                   - name: MENU_API_HOST
                     value: "menu-api"
               - name: php
-                image: quay-its.epfl.ch/svc0041/wp-php:2025-016
+                image: quay-its.epfl.ch/svc0041/wp-php:2025-017
                 resources:
                   limits: "{{ _limits_for_prod_only }}"
                   requests:

--- a/docker/wordpress-php/nginx-entrypoint.php
+++ b/docker/wordpress-php/nginx-entrypoint.php
@@ -175,6 +175,10 @@ enable_wp_debug();
 // This is 2025. We don't do plain HTTP anymore.
 $_SERVER['HTTPS'] = '1';
 
+// Disable the auto-updater and other portions of WordPress that want
+// to alter their own PHP code:
+define('DISALLOW_FILE_MODS', 1);
+
 // Define the EPFL_SITE_NAME
 // This match the `site['metadata']['name']` to the 
 // k8s's WordPress object.


### PR DESCRIPTION
- This is not going to work on Kubernetes anyway
- Although correlation is not causation, I found some [interesting evidence](https://grafana-prod-route-grafana-prod.apps.ocpitsp0001.xaas.epfl.ch/goto/6ZfSxZcNR?orgId=1) that the self-upgrade attempts might have something to do with our serving infrastructure buckling every night around 22:25PM CEST for the last 9 days:

<img width="1122" alt="image" src="https://github.com/user-attachments/assets/4d05e320-7948-48f1-bc5b-766c508cef75" />
