### PR TITLE
[fix] create menu api service account

### DIFF
--- a/ansible/roles/wordpress-namespace/tasks/menu-api.yml
+++ b/ansible/roles/wordpress-namespace/tasks/menu-api.yml
@@ -83,9 +83,10 @@
             labels:
               app: menu-api
           spec:
+            serviceAccountName: menu-api
             containers:
               - name: menu-api
-                image: "quay-its.epfl.ch/svc0041/menu-api:2025-001-{{ inventory_deployment_stage }}"
+                image: "quay-its.epfl.ch/svc0041/menu-api:2025-004-{{ inventory_deployment_stage }}"
                 resources:
                   limits:
                     cpu: 500m
@@ -135,3 +136,47 @@
         selector:
           app: menu-api
         type: ClusterIP
+
+
+- name: ServiceAccount/menu-api
+  kubernetes.core.k8s:
+    state: present
+    definition:
+      apiVersion: v1
+      kind: ServiceAccount
+      metadata:
+        name: menu-api
+        namespace: "{{ inventory_namespace }}"
+
+- name: Role/menu-api
+  kubernetes.core.k8s:
+    state: present
+    definition:
+      apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
+        name: menu-api
+        namespace: "{{ inventory_namespace }}"
+      rules:
+        - apiGroups: ['wordpress.epfl.ch']
+          resources:
+            - wordpresssites
+          verbs: ['get', 'list', 'watch']
+
+- name: RoleBinding/menu-api
+  kubernetes.core.k8s:
+    state: present
+    definition:
+      apiVersion: rbac.authorization.k8s.io/v1
+      kind: RoleBinding
+      metadata:
+        name: menu-api
+        namespace: "{{ inventory_namespace }}"
+      subjects:
+        - kind: ServiceAccount
+          name: menu-api
+          namespace: "{{ inventory_namespace }}"
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: Role
+        name: menu-api

--- a/ansible/roles/wordpress-namespace/tasks/menu-api.yml
+++ b/ansible/roles/wordpress-namespace/tasks/menu-api.yml
@@ -14,7 +14,8 @@
         namespace: "{{ inventory_namespace }}"
       data:
         menu-api-config.yaml: |
-          POD_NAME: ""
+          WP_SERVICE_NAME: "wp-nginx"
+          WP_SERVICE_PORT: 80
           SERVICE_PORT: "3001"
           PATH_REFRESH_FILE: "./data"
           PATH_SITES_FILE: ""

--- a/ansible/roles/wordpress-namespace/tasks/menu-api.yml
+++ b/ansible/roles/wordpress-namespace/tasks/menu-api.yml
@@ -87,7 +87,7 @@
             serviceAccountName: menu-api
             containers:
               - name: menu-api
-                image: "quay-its.epfl.ch/svc0041/menu-api:2025-004-{{ inventory_deployment_stage }}"
+                image: "quay-its.epfl.ch/svc0041/menu-api:2025-004"
                 resources:
                   limits:
                     cpu: 500m


### PR DESCRIPTION
Menu-api needs a service account to be able to enumerate `WordpressSite`s from k8s