### PR TITLE
[fix] some bit rot in persistence configuration-as-code

### DIFF
--- a/ansible/roles/wordpress-namespace/tasks/main.yml
+++ b/ansible/roles/wordpress-namespace/tasks/main.yml
@@ -5,18 +5,7 @@
   import_tasks:
     file: k8s-login.yml
 
-- name: MariaDB server
-  include_tasks:
-    file: mariadb.yml
-    apply:
-      tags:
-        - wp
-        - wp.mariadb
-  tags:
-    - wp
-    - wp.mariadb
-
-- name: Storage (for files)
+- name: Storage
   include_tasks:
     file: storage.yml
     apply:
@@ -31,6 +20,17 @@
     # tenants cannot “steal” it from us) is for ITOP-SDDC to manage:
     _storage_managed: >-
       {{ inventory_has_cluster_admin | default(False) }}
+
+- name: MariaDB server
+  include_tasks:
+    file: mariadb.yml
+    apply:
+      tags:
+        - wp
+        - wp.mariadb
+  tags:
+    - wp
+    - wp.mariadb
 
 - name: Serving secrets (for plugins, outgoing SMTP etc.)
   include_tasks:

--- a/ansible/roles/wordpress-namespace/tasks/nginx.yml
+++ b/ansible/roles/wordpress-namespace/tasks/nginx.yml
@@ -210,7 +210,7 @@
                     containerPort: 9145
                     protocol: TCP  
                 volumeMounts:
-                  - name: wp-data
+                  - name: wordpress-data
                     mountPath: /wp-data/
                     readOnly: true
                   - name: fpm-socket
@@ -244,7 +244,7 @@
                     cpu: '{{ _request_cpu_serving }}'
                     memory: '{{ _request_ram }}'
                 volumeMounts:
-                  - name: wp-data
+                  - name: wordpress-data
                     mountPath: /wp-data/
                   - name: fpm-socket
                     mountPath: /run/php-fpm
@@ -269,7 +269,7 @@
             volumes:
               - name: fpm-socket
                 emptyDir: {}
-              - name: wp-data
+              - name: wordpress-data
                 persistentVolumeClaim:
                   claimName: wordpress-data
               # Uncomment the next three lines to embug the nginx configuration

--- a/ansible/roles/wordpress-namespace/tasks/storage.yml
+++ b/ansible/roles/wordpress-namespace/tasks/storage.yml
@@ -47,6 +47,9 @@
         storageClass:
           defaultClass: false
           name: "wordpress-nfs-{{ item }}"
+        resources:
+          requests:
+            cpu: 100m
 
 - name: PersistentVolumeClaim/wordpress-data
   kubernetes.core.k8s:

--- a/ansible/roles/wordpress-namespace/tasks/storage.yml
+++ b/ansible/roles/wordpress-namespace/tasks/storage.yml
@@ -2,14 +2,14 @@
   include_vars: storage-vars.yml
 
 - when: _storage_managed
-  name: PersistentVolume/wp-data
+  name: PersistentVolume/wordpress-data
   kubernetes.core.k8s:
     state: present
     definition:
       apiVersion: v1
       kind: PersistentVolume
       metadata:
-        name: wp-data
+        name: wordpress-data
       spec:
         accessModes:
         - ReadWriteMany
@@ -26,16 +26,16 @@
         claimRef:
           kind: PersistentVolumeClaim
           namespace: "{{ inventory_namespace }}"
-          name: wp-data
+          name: wordpress-data
 
-- name: PersistentVolumeClaim/wp-data
+- name: PersistentVolumeClaim/wordpress-data
   kubernetes.core.k8s:
     state: present
     definition:
       apiVersion: v1
       kind: PersistentVolumeClaim
       metadata:
-        name: wp-data
+        name: wordpress-data
         namespace: "{{ inventory_namespace }}"
       spec:
         accessModes:

--- a/ansible/roles/wordpress-namespace/tasks/storage.yml
+++ b/ansible/roles/wordpress-namespace/tasks/storage.yml
@@ -28,6 +28,26 @@
           namespace: "{{ inventory_namespace }}"
           name: wordpress-data
 
+- name: NfsSubdirExternalProvisioner's
+  with_items:
+   - data
+   - db
+  kubernetes.core.k8s:
+    state: present
+    definition:
+      apiVersion: nfs.epfl.ch/v1alpha1
+      kind: NfsSubdirProvisioner
+      metadata:
+        name: "wordpress-{{ item }}"
+        namespace: "{{ inventory_namespace }}"
+      spec:
+        nfs:
+          server: "{{ storage_nas[inventory_deployment_stage].nfs_server }}"
+          path:  "{{ storage_nas[inventory_deployment_stage].path }}/wordpress-{{ item }}"
+        storageClass:
+          defaultClass: false
+          name: "wordpress-nfs-{{ item }}"
+
 - name: PersistentVolumeClaim/wordpress-data
   kubernetes.core.k8s:
     state: present

--- a/ansible/roles/wordpress-namespace/tasks/storage.yml
+++ b/ansible/roles/wordpress-namespace/tasks/storage.yml
@@ -22,7 +22,7 @@
         storageClassName: ""
         nfs:
           server: "{{ storage_nas[inventory_deployment_stage].nfs_server }}"
-          path:  "{{ storage_nas[inventory_deployment_stage].path }}"
+          path:  "{{ storage_nas[inventory_deployment_stage].path }}/wordpress-data"
         claimRef:
           kind: PersistentVolumeClaim
           namespace: "{{ inventory_namespace }}"

--- a/ansible/roles/wordpress-namespace/tasks/storage.yml
+++ b/ansible/roles/wordpress-namespace/tasks/storage.yml
@@ -62,8 +62,8 @@
           - ReadWriteMany
         resources:
           requests:
-            storage: 1Gi
-        storageClassName: ""
+            storage: 10Gi
+        storageClassName: wordpress-nfs-data
 
 # During the transition period, we can read from the old volumes:
 

--- a/ansible/roles/wordpress-namespace/vars/storage-vars.yml
+++ b/ansible/roles/wordpress-namespace/vars/storage-vars.yml
@@ -1,7 +1,7 @@
 storage_nas:
   test:
     nfs_server: nas-app-ma-nfs1.epfl.ch
-    path: /svc0041_si_openshift_app_wwp_test_app/wordpress-data
+    path: /svc0041_si_openshift_app_wwp_test_app
   production:
     nfs_server: nas-app-ma-nfs2.epfl.ch
-    path: /svc0041_wordpress_app/wordpress-data
+    path: /svc0041_wordpress_app

--- a/ansible/roles/wordpress-namespace/vars/storage-vars.yml
+++ b/ansible/roles/wordpress-namespace/vars/storage-vars.yml
@@ -3,5 +3,5 @@ storage_nas:
     nfs_server: nas-app-ma-nfs1.epfl.ch
     path: /svc0041_si_openshift_app_wwp_test_app/wp-data
   production:
-    nfs_server: nas-app-ma-nfs1.epfl.ch
-    path: /si_openshift_app_wwp_app/wp-data
+    nfs_server: nas-app-ma-nfs2.epfl.ch
+    path: /svc0041_wordpress_app/wordpress-data

--- a/ansible/roles/wordpress-namespace/vars/storage-vars.yml
+++ b/ansible/roles/wordpress-namespace/vars/storage-vars.yml
@@ -1,7 +1,7 @@
 storage_nas:
   test:
     nfs_server: nas-app-ma-nfs1.epfl.ch
-    path: /svc0041_si_openshift_app_wwp_test_app/wp-data
+    path: /svc0041_si_openshift_app_wwp_test_app/wordpress-data
   production:
     nfs_server: nas-app-ma-nfs2.epfl.ch
     path: /svc0041_wordpress_app/wordpress-data


### PR DESCRIPTION
The PVCs and XaaS-side NAS subdirectories were renamed around January, 20th (for test) or 21th (for prod), but apparently these changes never made it to the configuration-as-code. Neither did the `NfsSubdirExternalProvisioner` objects that we need for our NFS-provisioned storage scheme.

While we are in there:
- Tune the CPU reservation in said `NfsSubdirExternalProvisioner`s, freeing almost one full CPU in our tiny test namespace
- Reorder `-t wp.storage` before `-t wp.mariadb`, now that the latter depends on the former
