### PR TITLE
[feature] Improve basic alerting

### DIFF
--- a/ansible/roles/wordpress-namespace/tasks/monitoring.yml
+++ b/ansible/roles/wordpress-namespace/tasks/monitoring.yml
@@ -24,7 +24,7 @@
       spec:
         route:
           receiver: "telegram"
-          groupBy: ["environment"]
+          groupBy: ["alertname"]
           groupWait: 20s
           groupInterval: 5m
           repeatInterval: 3h
@@ -43,11 +43,11 @@
                   {% raw %}
                   {{ range .Alerts }}
                   {{ if eq .Status "firing" }}
-                  🔥 FIRING [{{ .Labels.environment }}] -- {{ .Annotations.summary }}
+                  🔥 FIRING -- {{ .Annotations.summary }}
                   {{ .Annotations.description }}
                   Started at (UTC): {{ .StartsAt.Format "2006-01-02 15:04:05" }}
                   {{ else if eq .Status "resolved" }}
-                  ✅ RESOLVED [{{ .Labels.environment }}] -- {{ .Annotations.summary }}
+                  ✅ RESOLVED -- {{ .Annotations.summary }}
                   {{ .Annotations.description }}
                   Started at (UTC): {{ .StartsAt.Format "2006-01-02 15:04:05" }}
                   Ended at (UTC): {{ .EndsAt.Format "2006-01-02 15:04:05" }}
@@ -74,7 +74,6 @@
                   != kube_deployment_spec_replicas{deployment="wp-nginx", namespace="{{ inventory_namespace }}"}
                 for: 3m
                 labels:
-                  environment: "{{ inventory_deployment_stage | upper }}"
                   severity: critical
                   sendto: telegram
                 annotations:
@@ -87,7 +86,6 @@
                   up{namespace="{{ inventory_namespace }}"} == 0
                 for: 3m
                 labels:
-                  environment: "{{ inventory_deployment_stage | upper }}"
                   severity: critical
                   sendto: telegram
                 annotations:

--- a/ansible/roles/wordpress-namespace/tasks/monitoring.yml
+++ b/ansible/roles/wordpress-namespace/tasks/monitoring.yml
@@ -91,5 +91,9 @@
                   severity: critical
                   sendto: telegram
                 annotations:
-                  summary: "Monitoring is down"
-                  description: "The monitoring (internal) is down for over 3 minutes."
+                  summary: "Monitoring target is down"
+                  description: >-
+                    {% raw -%}
+                    The target {{ $labels.endpoint }} (job: {{ $labels.job }}, pod: {{ $labels.pod }})
+                    has been down for over 3 minutes.
+                    {%- endraw %}

--- a/ansible/roles/wordpress-namespace/vars/monitoring-secrets.yml
+++ b/ansible/roles/wordpress-namespace/vars/monitoring-secrets.yml
@@ -1,4 +1,5 @@
-_monitoring_secrets: "{{ lookup('file', '/keybase/team/epfl_wp_prod/monitoring-internal.yml') | from_yaml }}"
+_keybase_team_wp: "{{ 'epfl_wp_prod' if inventory_namespace == 'svc0041p-wordpress' else 'epfl_wp_test' }}"
+_monitoring_secrets: "{{ lookup('file', '/keybase/team/{{ _keybase_team_wp }}/monitoring-internal.yml') | from_yaml }}"
 _telegram_alert: "{{ _monitoring_secrets.telegram_alert }}"
 
 telegram_bot_token: "{{ _telegram_alert.bot_token }}"


### PR DESCRIPTION
**Description**

1. Add some details on monitoring alerts message (for all 'up' metrics), as we have actually 3 different metric endpoints (nginx, php-fpm, mariadb).
2. Send alerts from the test environment to a dedicated Telegram group for this use case.