### PR TITLE
[fix] MariaDB alert message

### DIFF
--- a/ansible/roles/wordpress-namespace/tasks/monitoring.yml
+++ b/ansible/roles/wordpress-namespace/tasks/monitoring.yml
@@ -142,10 +142,7 @@
                 annotations:
                   summary: "Too many MariaDB restarts"
                   description: >-
-                    {% raw -%}
-                    More than once MariaDB (pod: {{ $labels.pod }}, instance: {{ $labels.instance }})
-                    {%- endraw %}
-                    has restarted in the last {{ _mariadb_restarts_window_minutes }} minutes.
+                    More than one MariaDB has restarted in the last {{ _mariadb_restarts_window_minutes }} minutes.
           - name: pod-alerts
             rules:
               - alert: WordPressNginxPodCountMismatch


### PR DESCRIPTION
**Description**

Do not print the `pod` and `instance` labels for this alert.