### PR TITLE
[investigate] Disable wp-cron.php on a trial basis

### DIFF
--- a/docker/wordpress-nginx/nginx.tmpl
+++ b/docker/wordpress-nginx/nginx.tmpl
@@ -119,7 +119,7 @@ http {
 				prometheus:collect()
 			}
 		}
-	}	
+	}
 
 	# `wordpress`-class ingress snippets start here.
 	{{ range $server := $servers }}
@@ -129,7 +129,7 @@ http {
 		{{ $hasRootLocation := false }}
 
 		{{ range $location := $server.Locations }}
-			####################### START LOCATION ####################### 
+			####################### START LOCATION #######################
 			{{ $path := buildLocation $location false }}
 
 			# ------------------------------------------------------------- #
@@ -140,13 +140,13 @@ http {
 				# Service port   : {{ $ing.ServicePort | quote }};
 				# Location path  : {{ $ing.Path | escapeLiteralDollar | quote }};
 				# Ingress path   : {{ $location.IngressPath | quote }};
-			
+
 			# ------------------------------------------------------------- #
 
 {{/* Verify if ConfigurationSnippet is provided and set as expected when the path is root (/).
      The ConfigurationSnippet may introduce unanticipated values at the root path.
      Ensure that the ingress have a Service name.
-     NOTE: Current behavior with root path ConfigurationSnippet is under review, 
+     NOTE: Current behavior with root path ConfigurationSnippet is under review,
      and a fix will be included in a future update. */}}
 			{{ if and (eq $location.Path "/") (not (empty $ing.Service)) }}
 				{{ $hasRootLocation = true }}
@@ -184,7 +184,7 @@ http {
 				location {{ $path }} {
 					{{ $location.ConfigurationSnippet }}
 				}
-				
+
 			{{ else }}
 
 {{/* This is a supplemental Location that the controller emits as a

--- a/docker/wordpress-php/Dockerfile
+++ b/docker/wordpress-php/Dockerfile
@@ -16,6 +16,9 @@ COPY --from=wp-base /usr/local/bin/wp /usr/local/bin/wp
 COPY --from=wp-base /var/www/.composer/ /var/www/.composer/
 COPY --from=wp-base /var/www/.wp-cli/ /var/www/.wp-cli/
 
+# We don't do the wp-cron out of the interactive Web server:
+RUN find /wp/ -name wp-cron.php -delete
+
 COPY msmtprc /etc/msmtprc
 
 COPY merge_fpm_confs.pl /usr/local/lib/


### PR DESCRIPTION
This is to confirm that the daily 22:22 outage of
https://go.epfl.ch/WPN-318 fame, is caused by a surge of wp-cron.php
traffic (as the evidence in CloudFlare currently suggests):

![image](https://github.com/user-attachments/assets/f6a25457-0a99-4d80-8e44-2c11da0ac33d)
