### PR TITLE
[feature] `-t quay`: obtain robot account tokens, create image pull secrets

### DIFF
--- a/ansible/playbook.yml
+++ b/ansible/playbook.yml
@@ -22,12 +22,20 @@
     import_tasks:
       file: tasks/k8s-login.yml
 
-# TODO: We should integrate with Quay here. At a minimum we need to create
-# one `imagePullSecret` for every namespace.
+- name: Quay integration
+  # Like above, members of the all_wordpress_namespaces are OpenShift
+  # namespaces, rather than hosts
+  hosts: all_namespaces
+  gather_facts: no    # Ansible facts are useless for this play
+  vars_files: ansible-k8s-credentials.yml
+  environment:
+    K8S_AUTH_KUBECONFIG: "{{ k8s_auth_kubeconfig }}"
+  roles:
+    - role: roles/quay-consumer-namespace
 
 - name: OLM catalog image
   hosts: namespace|svc0041t-wordpress
-  gather_facts: False
+  gather_facts: no
   vars_files: ansible-k8s-credentials.yml
   environment:
     K8S_AUTH_KUBECONFIG: "{{ k8s_auth_kubeconfig }}"
@@ -35,10 +43,8 @@
     - role: roles/olm-catalog
 
 - name: WordPress namespaces
-  # Like above, members of the all_wordpress_namespaces are OpenShift
-  # (or RKE2) namespaces, rather than hosts
   hosts: all_namespaces
-  gather_facts: no    # Ansible facts are useless for this play
+  gather_facts: no
   vars_files: ansible-k8s-credentials.yml
   environment:
     K8S_AUTH_KUBECONFIG: "{{ k8s_auth_kubeconfig }}"

--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -4,3 +4,5 @@ roles:
 
 collections:
 - name: epfl_si.actions
+- name: epfl_si.quay
+  version: ">=0.4.0"

--- a/ansible/roles/olm-catalog/tasks/buildconfig-prerequisites.yml
+++ b/ansible/roles/olm-catalog/tasks/buildconfig-prerequisites.yml
@@ -7,8 +7,11 @@
       metadata:
         name: builder-pull-secret
         namespace: "{{ inventory_namespace }}"
-      data:
-        .dockerconfigjson: "{{ builder_pull_secret_config | to_json | b64encode }}"
+      stringData:
+        .dockerconfigjson: >-
+          {{ lookup("epfl_si.quay.robot_account", quay_organization, catalog_builder_robot_account_name,
+                                                  token=quay_botfather_token)
+          | epfl_si.quay.format_docker_config_json | string }}
 
 - name: Service Account for Build Config
   kubernetes.core.k8s:

--- a/ansible/roles/olm-catalog/tasks/main.yml
+++ b/ansible/roles/olm-catalog/tasks/main.yml
@@ -4,7 +4,15 @@
 # (through the same Quay instance) in both test and production namespaces.
 
 - tags: always
-  include_vars: catalog-vars.yml
+  include_vars: "{{ item }}"
+  with_items:
+    - catalog-vars.yml
+    - ../../../vars/quay-vars.yml
+
+- tags: always
+  include_vars:
+    file: ../../../vars/quay-secrets.yml
+    name: quay_secrets
 
 - name: "Build Config Prerequisites"
   include_tasks:

--- a/ansible/roles/olm-catalog/vars/catalog-vars.yml
+++ b/ansible/roles/olm-catalog/vars/catalog-vars.yml
@@ -1,10 +1,3 @@
 isas_fsd_catalog_git_uri: https://github.com/epfl-si/isas-fsd-catalog
 
-_builder_secrets: "{{ lookup('file', '/keybase/team/epfl_wp_test/WordPress-Next/ocp4_builder_secrets.yml') | from_yaml }}"
-
-_builder_robot_credentials: "{{ builder_secrets.quay.pull_robot.name }}:{{ _builder_secrets.quay.pull_robot.token }}"
-
-builder_pull_secret_config:
-  auths:
-    "quay-its.epfl.ch":
-      "auth": "{{ _builder_robot_credentials | b64encode }}"
+catalog_builder_robot_account_name: svc0041+builder_robot_account

--- a/ansible/roles/quay-consumer-namespace/tasks/main.yml
+++ b/ansible/roles/quay-consumer-namespace/tasks/main.yml
@@ -1,0 +1,7 @@
+- include_tasks:
+     file: quay-puller-robot-account.yml
+     apply:
+       tags:
+          - quay
+  tags:
+    - quay

--- a/ansible/roles/quay-consumer-namespace/tasks/quay-puller-robot-account.yml
+++ b/ansible/roles/quay-consumer-namespace/tasks/quay-puller-robot-account.yml
@@ -1,0 +1,23 @@
+- tags: always
+  include_vars: ../../../vars/quay-vars.yml
+
+- tags: always
+  include_vars:
+    file: ../../../vars/quay-secrets.yml
+    name: quay_secrets
+
+- name: "`Secret/{{ quay_puller_robot_account_name }}`"
+  kubernetes.core.k8s:
+    state: present
+    definition:
+      apiVersion: v1
+      kind: Secret
+      metadata:
+        name: "{{ quay_puller_secret_name }}"
+        namespace: "{{ inventory_namespace }}"
+      type: kubernetes.io/dockerconfigjson
+      stringData:
+        .dockerconfigjson: >-
+          {{ lookup("epfl_si.quay.robot_account", quay_organization, quay_puller_robot_account_name,
+                                                  token=quay_botfather_token)
+          | epfl_si.quay.format_docker_config_json | string }}

--- a/ansible/roles/wordpress-namespace/tasks/menu-api.yml
+++ b/ansible/roles/wordpress-namespace/tasks/menu-api.yml
@@ -1,4 +1,4 @@
-- include_vars: image-vars.yml
+- include_vars: ../../../vars/quay-vars.yml
   tags: always
 
 - name: ConfigMap/menu-api
@@ -120,7 +120,7 @@
                 configMap:
                   name: menu-api
             imagePullSecrets:
-              - name: "{{ image_pull_secret_name }}"
+              - name: "{{ quay_puller_secret_name }}"
   vars:
     _cpu_request: >-
       {{ "1" if inventory_deployment_stage == "production"

--- a/ansible/roles/wordpress-namespace/tasks/nginx.yml
+++ b/ansible/roles/wordpress-namespace/tasks/nginx.yml
@@ -1,5 +1,8 @@
-- include_vars: image-vars.yml
-  tags: always
+- tags: always
+  include_vars: "{{ item }}"
+  with_items:
+  - image-vars.yml
+  - ../../../vars/quay-vars.yml
 
 - name: ConfigMap/wp-nginx
   kubernetes.core.k8s:
@@ -133,7 +136,7 @@
                   - --log.level
                   - debug
             imagePullSecrets:
-              - name: "{{ image_pull_secret_name }}"
+              - name: "{{ quay_puller_secret_name }}"
             restartPolicy: Always
             volumes:
               - name: fpm-socket

--- a/ansible/roles/wordpress-namespace/vars/image-vars.yml
+++ b/ansible/roles/wordpress-namespace/vars/image-vars.yml
@@ -1,3 +1,1 @@
-image_pull_secret_name: "svc0041-svc0041-puller-pull-secret"
-
 nginx_deployment_images_tag: "2025-046"

--- a/ansible/vars/quay-secrets.yml
+++ b/ansible/vars/quay-secrets.yml
@@ -1,0 +1,40 @@
+# To edit the encrypted secrets below, you need eyaml installed.
+# Familiarize yourself with
+# https://puppet.com/blog/encrypt-your-data-using-hiera-eyaml first.
+# The edit command goes like this,
+#
+#   ansible/ansible-deps-cache/bin/eyaml edit -d \
+#     --pkcs7-public-key ansible/eyaml/epfl_wp_test.pem \
+#     ansible/vars/quay-secrets.yml
+#
+# 💡 This *will not* decrypt anything for you because chances are, you
+# don't need to decrypt secrets (YA RLY). For those cases where you
+# do, wielding the private key from Keybase is left as an exercise to
+# the reader.
+
+
+eyaml_keys:
+  priv: "/keybase/team/epfl_wp_test/eyaml-privkey.pem"
+  pub: "{{ playbook_dir }}/eyaml/epfl_wp_test.pem"
+
+quay:
+  # To regenerate this token:
+  # (paraphrased from https://docs.redhat.com/en/documentation/red_hat_quay/3/html-single/red_hat_quay_api_guide/index#token-overview)
+  #
+  # 1. Browse https://quay-its.epfl.ch/
+  # 2. **Make sure to log out and then back in.** Some token manipulation steps require either
+  #    that you have a fresh (less than a few minutes old) session, or that you type in your
+  #    password to re-autenticate. Unfortunately the latter will *not* work on quay-its.epfl.ch,
+  #    no matter what. (Mumble LDAP something something)
+  # 3. Browse https://quay-its.epfl.ch/organization/svc0041?tab=applications
+  # 4. (If not already done) Create the `ansible` application. Click the “Create New Application” button in the upper right corner; type in ansible and press Enter.
+  #
+  #    💡 If you get prompted for a password at this time, it means that you didn't read
+  #    the above instructions carefully. Sorry about that.
+  # 5. Click the `ansible` hyperlink
+  # 6. Click Generate Token (pictured by a cinema ticket)- in the left sidebar
+  # 7. Check the “Administer Organization” box and leave all others unchecked.
+  # 8. Click the Generate Access Token button (green) at the bottom
+  # 9. Click Authorize application
+  # 10. A token should appear. If it doesn't, see 💡, above.
+  org_admin_token: ENC[PKCS7,MIIBmQYJKoZIhvcNAQcDoIIBijCCAYYCAQAxggEhMIIBHQIBADAFMAACAQEwDQYJKoZIhvcNAQEBBQAEggEAByf6jY0/ce4JK8R+U+3zAamPg48eQcVT87mBYl2Z9k0gTHQj4e8cVnKCGYtDq4+Q7YK5F5doSMZ0UbPednt9R92/4Iw8+glLlRxwhVKpt/8BMWHzZ6yw0wIdO5TjtHSl9gT74/otxZ2jxCq126IfJS6H0rDC6SrVRYvxouKpEHZHuGPOKuhbDBM5eYQKzXHSuKWbDfmFG3wwT2HXzUiWFh8+ApFLR698jE9sFisGNYBHAZYIAl1nSKgXGzZ1LbwLGu0l2PG/jliYoNt20gUn4SL43w9gCShazXP3qGVmTxMNWESrJlCPt3AqTFbzGZmiTS1ooL7p7vl6GjupPaAq/TBcBgkqhkiG9w0BBwEwHQYJYIZIAWUDBAEqBBCIVqykAL+iQvKE/sVVyxCAgDCjMqa9zSaRf8pCUsCHWa739RQPhn6Kt7kKk+bBg3stnKA+bikxzRKne+ayZPHy7/Q=]

--- a/ansible/vars/quay-vars.yml
+++ b/ansible/vars/quay-vars.yml
@@ -1,6 +1,15 @@
+ansible_quay_hostname: quay-its.epfl.ch
+
+quay_organization: svc0041
+
 # Robot account whose credentials will be used to pull (almost) everything we need from Quay:
 quay_puller_robot_account_name: "svc0041+svc0041_puller"
 
 # This is the transformation that Quay itself suggests:
 quay_puller_secret_name: >-
   {{ quay_puller_robot_account_name | regex_replace('[_+]', '-') }}-pull-secret
+
+# `quay_secrets` is supposed to be loaded out of ./quay-secrets.yml for this to work:
+quay_botfather_token: >-
+  {{ quay_secrets.quay.org_admin_token
+  | eyaml(quay_secrets.eyaml_keys) }}

--- a/ansible/vars/quay-vars.yml
+++ b/ansible/vars/quay-vars.yml
@@ -1,0 +1,6 @@
+# Robot account whose credentials will be used to pull (almost) everything we need from Quay:
+quay_puller_robot_account_name: "svc0041+svc0041_puller"
+
+# This is the transformation that Quay itself suggests:
+quay_puller_secret_name: >-
+  {{ quay_puller_robot_account_name | regex_replace('[_+]', '-') }}-pull-secret


### PR DESCRIPTION
- New `quay-consumer-namespace` role, guarded by `-t quay`
- Download robot account tokens from the Quay API
- Create secrets out of them