### PR TITLE
[feature](WPN-343) Subdomains redirection

### DIFF
--- a/ansible/roles/wordpress-namespace/tasks/main.yml
+++ b/ansible/roles/wordpress-namespace/tasks/main.yml
@@ -47,13 +47,26 @@
         - wp
         - wp.web
         - wp.nginx
+  tags:
+    - wp
+    - wp.web
+    - wp.nginx
+
+- name: WordPress (Apache) redirector
+  include_tasks:
+    file: redirector.yml
+    apply:
+      tags:
+        - wp
+        - wp.redirector
+        - wp.apache
       vars:
         # For now, we manage Routes by hand (so as to revert them quickly if need be):
         _routing_managed: false
   tags:
     - wp
-    - wp.web
-    - wp.nginx
+    - wp.redirector
+    - wp.apache
 
 - name: "Menu API"
   include_tasks:

--- a/ansible/roles/wordpress-namespace/tasks/main.yml
+++ b/ansible/roles/wordpress-namespace/tasks/main.yml
@@ -60,9 +60,6 @@
         - wp
         - wp.redirector
         - wp.apache
-      vars:
-        # For now, we manage Routes by hand (so as to revert them quickly if need be):
-        _routing_managed: false
   tags:
     - wp
     - wp.redirector

--- a/ansible/roles/wordpress-namespace/tasks/redirector.yml
+++ b/ansible/roles/wordpress-namespace/tasks/redirector.yml
@@ -74,23 +74,3 @@
         selector:
           app: apache-redirector
         type: ClusterIP
-
-- name: PersistentVolumeClaim/wordpress-apache-redirector
-  kubernetes.core.k8s:
-    state: present
-    definition:
-      apiVersion: v1
-      kind: PersistentVolumeClaim
-      metadata:
-        name: wordpress-apache-redirector
-        namespace: "{{ inventory_namespace }}"
-      spec:
-        accessModes:
-          - ReadWriteMany
-        resources:
-          requests:
-            # This counts towards our OpenShift quota (despite the
-            # metering happening on different hardware altogether), so
-            # we want to pretend it costs almost nothing:
-            storage: 100Mi
-        storageClassName: wordpress-nfs-apache-redirector

--- a/ansible/roles/wordpress-namespace/tasks/redirector.yml
+++ b/ansible/roles/wordpress-namespace/tasks/redirector.yml
@@ -1,0 +1,96 @@
+- include_vars: image-vars.yml
+  tags: always
+
+- name: Deployment/apache-redirector
+  kubernetes.core.k8s:
+    state: present
+    definition:
+      apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: apache-redirector
+        namespace: "{{ inventory_namespace }}"
+        labels:
+          app: apache-redirector
+          app.kubernetes.io/managed-by: Ansible
+          app.kubernetes.io/name: apache-redirector
+          app.kubernetes.io/version: "redirector-{{ apache_redirector_image_tag }}"
+          team: isas-fsd
+      spec:
+        replicas: 1
+        selector:
+          matchLabels:
+            app: apache-redirector
+        strategy:
+          type: RollingUpdate
+        template:
+          metadata:
+            labels:
+              app: apache-redirector
+              version: "redirector-{{ apache_redirector_image_tag }}"
+          spec:
+            containers:
+              - name: apache
+                image: "quay-its.epfl.ch/svc0041/apache-redirector:{{ apache_redirector_image_tag }}"
+                command:
+                  - httpd-foreground
+                  - -C
+                  - PidFile /tmp/httpd.pid
+                resources:
+                  requests:
+                    cpu: "200m"
+                    memory: "200Mi"
+                ports:
+                  - containerPort: 8080
+                    protocol: TCP
+                volumeMounts:
+                  - name: wordpress-apache-redirector
+                    mountPath: /srv/subdomains
+                    readOnly: true
+            volumes:
+              - name: wordpress-apache-redirector
+                persistentVolumeClaim:
+                  claimName: wordpress-apache-redirector
+            imagePullSecrets:
+              - name: "{{ image_pull_secret_name }}"
+
+- name: Service/apache-redirector
+  kubernetes.core.k8s:
+    state: present
+    definition:
+      apiVersion: v1
+      kind: Service
+      metadata:
+        name: apache-redirector
+        namespace: "{{ inventory_namespace }}"
+        annotations:
+          authors: isas-fsd
+      spec:
+        ports:
+        - name: "80"
+          port: 80
+          protocol: TCP
+          targetPort: 8080
+        selector:
+          app: apache-redirector
+        type: ClusterIP
+
+- name: PersistentVolumeClaim/wordpress-apache-redirector
+  kubernetes.core.k8s:
+    state: present
+    definition:
+      apiVersion: v1
+      kind: PersistentVolumeClaim
+      metadata:
+        name: wordpress-apache-redirector
+        namespace: "{{ inventory_namespace }}"
+      spec:
+        accessModes:
+          - ReadWriteMany
+        resources:
+          requests:
+            # This counts towards our OpenShift quota (despite the
+            # metering happening on different hardware altogether), so
+            # we want to pretend it costs almost nothing:
+            storage: 100Mi
+        storageClassName: wordpress-nfs-apache-redirector

--- a/ansible/roles/wordpress-namespace/tasks/storage.yml
+++ b/ansible/roles/wordpress-namespace/tasks/storage.yml
@@ -51,6 +51,7 @@
         resources:
           requests:
             cpu: 100m
+            memory: 250Mi
 
 - name: PersistentVolumeClaim/wordpress-data
   kubernetes.core.k8s:

--- a/ansible/roles/wordpress-namespace/tasks/storage.yml
+++ b/ansible/roles/wordpress-namespace/tasks/storage.yml
@@ -32,7 +32,6 @@
   with_items:
     - data
     - db
-    - apache-redirector
   kubernetes.core.k8s:
     state: present
     definition:
@@ -113,3 +112,22 @@
           requests:
             storage: 1Gi
         storageClassName: ""
+
+- name: PersistentVolumeClaim/wordpress-apache-redirector
+  kubernetes.core.k8s:
+    state: present
+    definition:
+      apiVersion: v1
+      kind: PersistentVolumeClaim
+      metadata:
+        name: wordpress-apache-redirector
+        namespace: "{{ inventory_namespace }}"
+      spec:
+        accessModes:
+          - ReadWriteMany
+        resources:
+          requests:
+            storage: 100Mi
+        storageClassName: ""
+        volumeMode: Filesystem
+        volumeName: pv-svc0041-wordpress-apache-redirector

--- a/ansible/roles/wordpress-namespace/tasks/storage.yml
+++ b/ansible/roles/wordpress-namespace/tasks/storage.yml
@@ -22,7 +22,7 @@
         storageClassName: ""
         nfs:
           server: "{{ storage_nas[inventory_deployment_stage].nfs_server }}"
-          path:  "{{ storage_nas[inventory_deployment_stage].path }}/wordpress-data"
+          path: "{{ storage_nas[inventory_deployment_stage].path }}/wordpress-data"
         claimRef:
           kind: PersistentVolumeClaim
           namespace: "{{ inventory_namespace }}"
@@ -30,8 +30,9 @@
 
 - name: NfsSubdirExternalProvisioner's
   with_items:
-   - data
-   - db
+    - data
+    - db
+    - apache-redirector
   kubernetes.core.k8s:
     state: present
     definition:
@@ -43,7 +44,7 @@
       spec:
         nfs:
           server: "{{ storage_nas[inventory_deployment_stage].nfs_server }}"
-          path:  "{{ storage_nas[inventory_deployment_stage].path }}/wordpress-{{ item }}"
+          path: "{{ storage_nas[inventory_deployment_stage].path }}/wordpress-{{ item }}"
         storageClass:
           defaultClass: false
           name: "wordpress-nfs-{{ item }}"

--- a/ansible/roles/wordpress-namespace/vars/image-vars.yml
+++ b/ansible/roles/wordpress-namespace/vars/image-vars.yml
@@ -1,1 +1,5 @@
-nginx_deployment_images_tag: "2025-046"
+image_pull_secret_name: "svc0041-svc0041-puller-pull-secret"
+
+nginx_deployment_images_tag: "2025-047"
+
+apache_redirector_image_tag: "2025-001"

--- a/docker/apache-redirector/Dockerfile
+++ b/docker/apache-redirector/Dockerfile
@@ -1,0 +1,13 @@
+FROM httpd:2
+
+# Change the default port to 8080
+RUN sed -i "s/Listen 80/Listen ${PORT:-8080}/g" /usr/local/apache2/conf/httpd.conf
+
+# Activate the mod_rewrite
+RUN sed -i "s/^#LoadModule rewrite_module/LoadModule rewrite_module/" /usr/local/apache2/conf/httpd.conf
+
+# Change DocumentRoot and vhost's Directory to /srv/subdomains
+RUN sed -i 's|/usr/local/apache2/htdocs|/srv/subdomains|g' /usr/local/apache2/conf/httpd.conf
+
+# And finally, allow htaccess override
+RUN sed -i '/<Directory "\/srv\/subdomains">/,/<\/Directory>/c<Directory /srv/subdomains>\n\tOptions FollowSymLinks\n\tAllowOverride All\n\tRequire all granted\n<\/Directory>' /usr/local/apache2/conf/httpd.conf

--- a/docker/apache-redirector/Dockerfile
+++ b/docker/apache-redirector/Dockerfile
@@ -1,3 +1,3 @@
-FROM httpd:2
+FROM quay-its.epfl.ch/svc0041/httpd:2.4
 
 COPY httpd.conf /usr/local/apache2/conf/httpd.conf

--- a/docker/apache-redirector/Dockerfile
+++ b/docker/apache-redirector/Dockerfile
@@ -1,13 +1,3 @@
 FROM httpd:2
 
-# Change the default port to 8080
-RUN sed -i "s/Listen 80/Listen ${PORT:-8080}/g" /usr/local/apache2/conf/httpd.conf
-
-# Activate the mod_rewrite
-RUN sed -i "s/^#LoadModule rewrite_module/LoadModule rewrite_module/" /usr/local/apache2/conf/httpd.conf
-
-# Change DocumentRoot and vhost's Directory to /srv/subdomains
-RUN sed -i 's|/usr/local/apache2/htdocs|/srv/subdomains|g' /usr/local/apache2/conf/httpd.conf
-
-# And finally, allow htaccess override
-RUN sed -i '/<Directory "\/srv\/subdomains">/,/<\/Directory>/c<Directory /srv/subdomains>\n\tOptions FollowSymLinks\n\tAllowOverride All\n\tRequire all granted\n<\/Directory>' /usr/local/apache2/conf/httpd.conf
+COPY httpd.conf /usr/local/apache2/conf/httpd.conf

--- a/docker/apache-redirector/README.md
+++ b/docker/apache-redirector/README.md
@@ -1,0 +1,60 @@
+# Apache Redirector
+
+A minimal [httpd] container to manage redirections.
+
+## Local
+
+First, configure your `/etc/hosts`:
+```
+127.0.0.1 labs.epfl.ch
+127.0.0.1 redirect.epfl.ch
+127.0.0.1 rewrite.epfl.ch
+```
+
+Then, set up the container
+1. `docker build -t apache-redirector .`
+2. ```sh
+   docker run -dit -p 8080:8080 \
+     -v ./test/subdomains:/srv/subdomains \
+     --rm --name apache-redirector \
+     apache-redirector httpd-foreground
+   ``` 
+3. `docker logs -f apache-redirector`
+
+## Remote (kubernetes)
+
+Edit your `/etc/hosts` file to match the ClusterIP.
+
+Change the [routes.yml](./test/routes.yml) file to match your hostname and 
+namespace. Create the Kubernetes's objects and run the tests below.
+
+## Tests
+
+You can test these URLs
+
+- A file with 2 RewriteRules:
+  - `curl -I http://labs.epfl.ch:8080`
+    ```sh
+    HTTP/1.1 301 Moved Permanently
+    Location: https://www.epfl.ch/labs/
+    ```
+  - `curl -I http://labs.epfl.ch:8080/decode`
+    ```sh
+    HTTP/1.1 301 Moved Permanently
+    Location: https://www.epfl.ch/labs/decode/
+    ```
+- A file with a Redirect:  
+  `curl -I http://redirect.epfl.ch:8080`
+  ```sh
+  HTTP/1.1 302 Found
+  Location: https://zombo.com
+  ```
+- A file with a RewriteRules:  
+  `curl -I http://rewrite.epfl.ch:8080/this/is/zombocom`
+  ```sh
+  HTTP/1.1 303 See Other
+  Location: https://zombo.com/this/is/zombocom
+  ```
+
+
+[httpd]: https://hub.docker.com/_/httpd

--- a/docker/apache-redirector/httpd.conf
+++ b/docker/apache-redirector/httpd.conf
@@ -1,0 +1,106 @@
+ServerRoot "/usr/local/apache2"
+
+# Needed by the kubernetes service
+Listen 8080
+
+LoadModule mpm_event_module modules/mod_mpm_event.so
+LoadModule authn_file_module modules/mod_authn_file.so
+LoadModule authn_core_module modules/mod_authn_core.so
+LoadModule authz_host_module modules/mod_authz_host.so
+LoadModule authz_groupfile_module modules/mod_authz_groupfile.so
+LoadModule authz_user_module modules/mod_authz_user.so
+LoadModule authz_core_module modules/mod_authz_core.so
+LoadModule access_compat_module modules/mod_access_compat.so
+LoadModule auth_basic_module modules/mod_auth_basic.so
+LoadModule reqtimeout_module modules/mod_reqtimeout.so
+LoadModule filter_module modules/mod_filter.so
+LoadModule mime_module modules/mod_mime.so
+LoadModule log_config_module modules/mod_log_config.so
+LoadModule env_module modules/mod_env.so
+LoadModule headers_module modules/mod_headers.so
+LoadModule setenvif_module modules/mod_setenvif.so
+LoadModule version_module modules/mod_version.so
+LoadModule status_module modules/mod_status.so
+LoadModule autoindex_module modules/mod_autoindex.so
+LoadModule dir_module modules/mod_dir.so
+LoadModule alias_module modules/mod_alias.so
+LoadModule unixd_module modules/mod_unixd.so
+<IfModule unixd_module>
+    User www-data
+    Group www-data
+</IfModule>
+
+# Needed for the RewriteCond and RewriteRules in .htaccess
+LoadModule rewrite_module modules/mod_rewrite.so
+# Needed for VirtualDocumentRoot
+LoadModule vhost_alias_module modules/mod_vhost_alias.so
+
+ServerAdmin isas-fsd@groupes.epfl.ch
+
+<Directory />
+    AllowOverride none
+    Require all denied
+</Directory>
+
+
+UseCanonicalName Off
+VirtualDocumentRoot /srv/subdomains/%0/htdocs
+
+DocumentRoot "/srv/subdomains"
+<Directory /srv/subdomains>
+    Options FollowSymLinks
+    AllowOverride All
+    Require all granted
+</Directory>
+
+<IfModule dir_module>
+    DirectoryIndex index.html
+</IfModule>
+
+<Files ".ht*">
+    Require all denied
+</Files>
+
+ErrorLog /proc/self/fd/2
+
+LogLevel warn
+
+<IfModule log_config_module>
+    LogFormat "%h %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\"" combined
+    LogFormat "%h %l %u %t \"%r\" %>s %b" common
+
+    <IfModule logio_module>
+        LogFormat "%h %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\" %I %O" combinedio
+    </IfModule>
+
+    CustomLog /proc/self/fd/1 common
+</IfModule>
+
+<IfModule alias_module>
+    ScriptAlias /cgi-bin/ "/usr/local/apache2/cgi-bin/"
+</IfModule>
+
+<Directory "/usr/local/apache2/cgi-bin">
+    AllowOverride None
+    Options None
+    Require all granted
+</Directory>
+
+<IfModule headers_module>
+    RequestHeader unset Proxy early
+</IfModule>
+
+<IfModule mime_module>
+    TypesConfig conf/mime.types
+    AddType application/x-compress .Z
+    AddType application/x-gzip .gz .tgz
+</IfModule>
+
+<IfModule proxy_html_module>
+    Include conf/extra/proxy-html.conf
+</IfModule>
+
+<IfModule ssl_module>
+    SSLRandomSeed startup builtin
+    SSLRandomSeed connect builtin
+</IfModule>

--- a/docker/apache-redirector/httpd.conf
+++ b/docker/apache-redirector/httpd.conf
@@ -1,106 +1,39 @@
-ServerRoot "/usr/local/apache2"
-
 # Needed by the kubernetes service
 Listen 8080
+ServerAdmin isas-fsd@groupes.epfl.ch
 
 LoadModule mpm_event_module modules/mod_mpm_event.so
-LoadModule authn_file_module modules/mod_authn_file.so
-LoadModule authn_core_module modules/mod_authn_core.so
-LoadModule authz_host_module modules/mod_authz_host.so
-LoadModule authz_groupfile_module modules/mod_authz_groupfile.so
-LoadModule authz_user_module modules/mod_authz_user.so
 LoadModule authz_core_module modules/mod_authz_core.so
-LoadModule access_compat_module modules/mod_access_compat.so
-LoadModule auth_basic_module modules/mod_auth_basic.so
-LoadModule reqtimeout_module modules/mod_reqtimeout.so
-LoadModule filter_module modules/mod_filter.so
-LoadModule mime_module modules/mod_mime.so
 LoadModule log_config_module modules/mod_log_config.so
-LoadModule env_module modules/mod_env.so
-LoadModule headers_module modules/mod_headers.so
-LoadModule setenvif_module modules/mod_setenvif.so
-LoadModule version_module modules/mod_version.so
-LoadModule status_module modules/mod_status.so
-LoadModule autoindex_module modules/mod_autoindex.so
-LoadModule dir_module modules/mod_dir.so
-LoadModule alias_module modules/mod_alias.so
+LoadModule logio_module modules/mod_logio.so
+# AH00136: Server MUST relinquish startup privileges before accepting connections.
 LoadModule unixd_module modules/mod_unixd.so
 <IfModule unixd_module>
     User www-data
     Group www-data
 </IfModule>
-
-# Needed for the RewriteCond and RewriteRules in .htaccess
+# Needed for the Redirect, RewriteCond and RewriteRules in .htaccess
+LoadModule alias_module modules/mod_alias.so
 LoadModule rewrite_module modules/mod_rewrite.so
+
 # Needed for VirtualDocumentRoot
 LoadModule vhost_alias_module modules/mod_vhost_alias.so
 
-ServerAdmin isas-fsd@groupes.epfl.ch
+UseCanonicalName Off
+RewriteEngine On
+VirtualDocumentRoot /srv/subdomains/%0/htdocs
+ErrorLog /proc/self/fd/2
+LogLevel info
 
 <Directory />
-    AllowOverride none
-    Require all denied
-</Directory>
-
-
-UseCanonicalName Off
-VirtualDocumentRoot /srv/subdomains/%0/htdocs
-
-DocumentRoot "/srv/subdomains"
-<Directory /srv/subdomains>
-    Options FollowSymLinks
     AllowOverride All
-    Require all granted
 </Directory>
-
-<IfModule dir_module>
-    DirectoryIndex index.html
-</IfModule>
 
 <Files ".ht*">
     Require all denied
 </Files>
 
-ErrorLog /proc/self/fd/2
-
-LogLevel warn
-
 <IfModule log_config_module>
-    LogFormat "%h %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\"" combined
-    LogFormat "%h %l %u %t \"%r\" %>s %b" common
-
-    <IfModule logio_module>
-        LogFormat "%h %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\" %I %O" combinedio
-    </IfModule>
-
-    CustomLog /proc/self/fd/1 common
-</IfModule>
-
-<IfModule alias_module>
-    ScriptAlias /cgi-bin/ "/usr/local/apache2/cgi-bin/"
-</IfModule>
-
-<Directory "/usr/local/apache2/cgi-bin">
-    AllowOverride None
-    Options None
-    Require all granted
-</Directory>
-
-<IfModule headers_module>
-    RequestHeader unset Proxy early
-</IfModule>
-
-<IfModule mime_module>
-    TypesConfig conf/mime.types
-    AddType application/x-compress .Z
-    AddType application/x-gzip .gz .tgz
-</IfModule>
-
-<IfModule proxy_html_module>
-    Include conf/extra/proxy-html.conf
-</IfModule>
-
-<IfModule ssl_module>
-    SSLRandomSeed startup builtin
-    SSLRandomSeed connect builtin
+    LogFormat "%t %v:%p \"%{X-Forwarded-For}i\" %{Host}i %h %l %u \"%r\" %>s %O \"%{Referer}i\" \"%{User-Agent}i\"" vhost_combined
+    CustomLog /proc/self/fd/1 vhost_combined
 </IfModule>


### PR DESCRIPTION
This introduce a new pod "wp-redirector" that allows us to:
 - Keep the same filesystem layout for subdomains
 - Keep the Apache's `.htaccess` as they were in the previous infrastructure
 - Mange redirection with routes pointing to this pod