### PR TITLE
[feature] “cloud-native” wp-cli

### DIFF
--- a/docker/wordpress-php/Dockerfile
+++ b/docker/wordpress-php/Dockerfile
@@ -13,8 +13,6 @@ RUN set -e -x; \
 
 COPY --from=wp-base /wp /wp
 COPY --from=wp-base /usr/local/bin/wp /usr/local/bin/wp
-COPY --from=wp-base /var/www/.composer/ /var/www/.composer/
-COPY --from=wp-base /var/www/.wp-cli/ /var/www/.wp-cli/
 
 # We don't do the wp-cron out of the interactive Web server:
 RUN find /wp/ -name wp-cron.php -delete

--- a/docker/wp-base/Dockerfile
+++ b/docker/wp-base/Dockerfile
@@ -65,9 +65,8 @@ RUN rm /tmp/*.patch* /tmp/*.sh /tmp/*.json
 ######################################################################
 
 # build wp-gutenberg-epfl
-RUN set -e -x; for wp in /wp/*; do                                         \
-  cd $wp;                                                                  \
-  (cd wp-content/plugins/wp-gutenberg-epfl;                                \
+RUN set -e -x; for wp in /wp/*/wp-content; do                              \
+  (cd $wp/plugins/wp-gutenberg-epfl;                                       \
       rm -rf build; npm i --no-fund; npm run build; rm -rf node_modules);  \
   done
 
@@ -80,7 +79,7 @@ RUN set -e -x;   env; \
     git clone "$ELEMENTS_GIT_REPOSITORY" -b "$ELEMENTS_GIT_REF" /tmp/elements_build; \
     cd /tmp/elements_build; \
     yarn; yarn build; \
-    for wp in /wp/*; do cp -a dist/ $wp/wp-content/themes/wp-theme-2018/assets; done
+    for wp in /wp/*/wp-content; do cp -a dist/ $wp/themes/wp-theme-2018/assets; done
 
 ######################################################################
 # Symlinks in /wp

--- a/docker/wp-base/Dockerfile
+++ b/docker/wp-base/Dockerfile
@@ -14,19 +14,13 @@ RUN PIPX_BIN_DIR=/usr/local/bin pipx install awscli
 # Install wp-cli
 ######################################################################
 
-# Download latest WP-CLI:
-RUN curl -o /usr/local/bin/wp https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar
-RUN chmod 755 /usr/local/bin/wp
+COPY wp-cli-config.yml /wp/wp-cli/
+RUN curl -o /wp/wp-cli/wp-cli.phar https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar
 
-# Add Polylang-related extension packages to wp-cli
-COPY ./wp-cli-config.yml /var/www/.wp-cli/config.yml
-RUN mkdir /var/www/.composer; \
-    chown -R www-data:www-data /var/www/.wp-cli /var/www/.composer
+COPY wp.sh /usr/local/bin/wp
 
-RUN su -s /bin/sh www-data -c " \
-    set -e -x;                                                            \
-    wp package install https://github.com/epfl-si/polylang-cli/archive/master.zip ;     \
-    rm -f ~/.composer/auth.json"
+RUN mkdir /wp/wp-cli/packages; \
+    wp --allow-root package install https://github.com/epfl-si/polylang-cli/archive/master.zip
 
 ######################################################################
 # Install and patch WordPresses and dependencies
@@ -97,5 +91,3 @@ FROM scratch
 
 COPY --from=builder /wp /wp
 COPY --from=builder /usr/local/bin/wp /usr/local/bin/wp
-COPY --from=builder /var/www/.composer/ /var/www/.composer/
-COPY --from=builder /var/www/.wp-cli/ /var/www/.wp-cli/

--- a/docker/wp-base/Dockerfile
+++ b/docker/wp-base/Dockerfile
@@ -23,7 +23,6 @@ COPY ./wp-cli-config.yml /var/www/.wp-cli/config.yml
 RUN mkdir /var/www/.composer; \
     chown -R www-data:www-data /var/www/.wp-cli /var/www/.composer
 
-# Travis-specific arguments — See ../../.travis.yml
 RUN su -s /bin/sh www-data -c " \
     set -e -x;                                                            \
     wp package install https://github.com/epfl-si/polylang-cli/archive/master.zip ;     \

--- a/docker/wp-base/Dockerfile
+++ b/docker/wp-base/Dockerfile
@@ -26,7 +26,6 @@ RUN mkdir /var/www/.composer; \
 RUN su -s /bin/sh www-data -c " \
     set -e -x;                                                            \
     wp package install https://github.com/epfl-si/polylang-cli/archive/master.zip ;     \
-    wp package install https://github.com/epfl-si/wp-cli/archive/master.zip;            \
     rm -f ~/.composer/auth.json"
 
 ######################################################################

--- a/docker/wp-base/symlink-wp-versions.sh
+++ b/docker/wp-base/symlink-wp-versions.sh
@@ -4,8 +4,9 @@ set -e -x
 
 cd /wp
 
-for version in *;   # Sorted by version since the 1970s
+for wp_content_dir in */wp-content;   # Sorted by version since the 1970s
 do
+    version="$(dirname "$wp_content_dir")"
     major="$(echo "$version" |cut -d. -f1)"         # e.g. 5
     majorminor="$(echo "$version" |cut -d. -f1-2)"  # e.g. 5.2
 

--- a/docker/wp-base/wp-cli-config.yml
+++ b/docker/wp-base/wp-cli-config.yml
@@ -1,2 +1,1 @@
-apache_modules:
-  - mod_rewrite
+path: "/wp/6"

--- a/docker/wp-base/wp.sh
+++ b/docker/wp-base/wp.sh
@@ -1,0 +1,99 @@
+#!/bin/bash
+
+export WP_CLI_PACKAGES_DIR=/wp/wp-cli/packages
+export WP_CLI_CONFIG_PATH=/wp/wp-cli/wp-cli-config.yml
+
+configure_ingress () {
+    local wp_tmpdir="$(mktemp -d /tmp/wp-XXXXXX)"
+    trap "rm -rf '$wp_tmpdir'" EXIT INT TERM
+
+    export WP_CONFIG_PATH="$wp_tmpdir/wp-config.php"
+    kubectl get -o yaml ingress/"$1" | \
+        perl -ne 'next unless m/fastcgi_param (WP_DB_\S*?)\s+(\S*)/; print "$1=$2\n"' | \
+    (
+        eval "$(cat)"
+        cat > "$WP_CONFIG_PATH" <<EOF
+<?php
+
+define( 'DB_NAME', '$WP_DB_NAME' );
+
+/** Database username */
+define( 'DB_USER', '$WP_DB_USER' );
+
+/** Database password */
+define( 'DB_PASSWORD', '$WP_DB_PASSWORD' );
+
+/** Database hostname */
+define( 'DB_HOST', '$WP_DB_HOST' );
+
+/** Database charset to use in creating database tables. */
+define( 'DB_CHARSET', 'utf8' );
+
+/** The database collate type. Don't change this if in doubt. */
+define( 'DB_COLLATE', '' );
+
+EOF
+    )
+    cat >> "$WP_CONFIG_PATH" <<'EOF'
+
+
+/**#@-*/
+
+/**
+ * WordPress database table prefix.
+ *
+ * You can have multiple installations in one database if you give each
+ * a unique prefix. Only numbers, letters, and underscores please!
+ */
+$table_prefix = 'wp_';
+
+
+/* Add any custom values between this line and the "stop editing" line. */
+
+
+
+/**
+ * For developers: WordPress debugging mode.
+ *
+ * Change this to true to enable the display of notices during development.
+ * It is strongly recommended that plugin and theme developers use WP_DEBUG
+ * in their development environments.
+ *
+ * For information on other constants that can be used for debugging,
+ * visit the documentation.
+ *
+ * @link https://wordpress.org/support/article/debugging-in-wordpress/
+ */
+if ( ! defined( 'WP_DEBUG' ) ) {
+	define( 'WP_DEBUG', false );
+}
+
+/* That's all, stop editing! Happy publishing. */
+
+/** Absolute path to the WordPress directory. */
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ . '/' );
+}
+
+/** Sets up WordPress vars and included files. */
+require_once ABSPATH . 'wp-settings.php';
+EOF
+}
+
+declare -a wp_cli_args
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+      --ingress)
+          configure_ingress "$2"
+          shift; shift ;;
+      --ingress=*)
+          configure_ingress "$(echo "$1" |cut -d= -f2-)"
+          shift ;;
+      *)
+          wp_cli_args+=("$1")
+          shift ;;
+  esac
+done
+
+
+exec php /wp/wp-cli/wp-cli.phar "${wp_cli_args[@]}"


### PR DESCRIPTION
- Host it under `/wp/wp-cli` (as well as its packages, in the `wp package install` sense)
- Provide configuration and a shell wrapper sufficient to make
  ```
  wp --ingress=www-labs-jaksic-lab plugin list
  ```
  work