### PR TITLE
[fix] Shell-quote-proof inventory

### DIFF
--- a/ansible/inventory/prod/wordpress_namespaces.yml
+++ b/ansible/inventory/prod/wordpress_namespaces.yml
@@ -11,7 +11,7 @@ all_namespaces:
           vars:
             inventory_deployment_stage: production
           "hosts":   # Not real hosts, hence the scarequotes
-            namespace|svc0041p-wordpress:
+            namespace/svc0041p-wordpress:
               inventory_namespace: svc0041p-wordpress
               inventory_openshift:
                 domain: ocpitsp0001.xaas.epfl.ch

--- a/ansible/inventory/test/wordpress_namespaces.yml
+++ b/ansible/inventory/test/wordpress_namespaces.yml
@@ -11,11 +11,11 @@ all_namespaces:
           vars:
             inventory_deployment_stage: test
           "hosts":   # Not real hosts, hence the scarequotes
-            namespace|svc0041t-wordpress:
+            namespace/svc0041t-wordpress:
               inventory_namespace: svc0041t-wordpress
               inventory_openshift:
                 domain: ocpitst0001.xaas.epfl.ch
-            namespace|wordpress-test-in-okd:
+            namespace/wordpress-test-in-okd:
               inventory_namespace: wordpress-test
               inventory_has_cluster_admin: True
               inventory_has_only_one_worker_node: True


### PR DESCRIPTION
This makes

```
wpsible -l namespace/wordpress-test
```

work as you would expect, which the piped version wouldn't.