### PR TITLE
[feature] Protect wp-admin and inside from outside EPFL network

### DIFF
--- a/docker/wordpress-php/nginx-entrypoint.php
+++ b/docker/wordpress-php/nginx-entrypoint.php
@@ -61,10 +61,9 @@ function get_wp_entrypoint () {
 
     $entrypoint_path = substr($entrypoint_path, strlen($to_chop));
 
-    if (
-        ( isset($_SERVER['HTTP_X_EPFL_INTERNAL']) && strpos($entrypoint_path, 'wp-admin') !== false )
-        || $_SERVER['HTTP_HOST'] === 'inside.epfl.ch'
-    ) {
+    if  (( isset($_SERVER['HTTP_X_EPFL_INTERNAL']) && strtoupper($_SERVER['HTTP_X_EPFL_INTERNAL']) != 'TRUE') 
+        && ( strpos($entrypoint_path, 'wp-admin') !== false || $_SERVER['HTTP_HOST'] === 'inside.epfl.ch' ))
+    {
         header('Location: https://www.epfl.ch/campus/services/en/vpn-error/', true, 302);
         exit();
     }

--- a/docker/wordpress-php/nginx-entrypoint.php
+++ b/docker/wordpress-php/nginx-entrypoint.php
@@ -61,6 +61,14 @@ function get_wp_entrypoint () {
 
     $entrypoint_path = substr($entrypoint_path, strlen($to_chop));
 
+    if (
+        ( isset($_SERVER['HTTP_X_EPFL_INTERNAL']) && strpos($entrypoint_path, 'wp-admin') !== false )
+        || $_SERVER['HTTP_HOST'] === 'inside.epfl.ch'
+    ) {
+        header('Location: https://www.epfl.ch/campus/services/en/vpn-error/', true, 302);
+        exit();
+    }
+
     if ( substr($entrypoint_path, -4) === '.php' ) {
         return chop_leading_slashes($entrypoint_path);
     } elseif ( basename($entrypoint_path) === 'wp-admin' ) {


### PR DESCRIPTION
Test if header X-EPFL-Internal is true for wp-admin and inside else redirect to VPN error page.

https://erpdev.atlassian.net/browse/WPN-289