### PR TITLE
[bump] serving images to version 2025-131

### DIFF
--- a/ansible/roles/wordpress-namespace/vars/image-vars.yml
+++ b/ansible/roles/wordpress-namespace/vars/image-vars.yml
@@ -1,5 +1,5 @@
 image_pull_secret_name: "svc0041-svc0041-puller-pull-secret"
 
-nginx_deployment_images_tag: "2025-115"
+nginx_deployment_images_tag: "2025-131"
 
 apache_redirector_image_tag: "2025-007"


### PR DESCRIPTION
Currently available for testing at https://wpn-test.epfl.ch/