### PR TITLE
[bump] wp-cron image to version 2025-039

### DIFF
--- a/ansible/roles/wordpress-namespace/tasks/wp-cron.yml
+++ b/ansible/roles/wordpress-namespace/tasks/wp-cron.yml
@@ -25,7 +25,7 @@
                 serviceAccountName: wp-cron
                 containers:
                   - name: wp-cron
-                    image: "quay-its.epfl.ch/svc0041/wp-cron:2025-038"
+                    image: "quay-its.epfl.ch/svc0041/wp-cron:2025-039"
                     env:
                       - name: K8S_NAMESPACE
                         valueFrom:


### PR DESCRIPTION
(The wp-base underlying) this image contains https://github.com/epfl-si/wp-plugin-pushgateway/commit/f74542340c4c2a5ac59ab6b20410f4325ae47b12 which we want to have working ASAP.