### PR TITLE
[fix] Add status when it doesn't exist

### DIFF
--- a/ansible/roles/wordpress-namespace/tasks/wp-cron.yml
+++ b/ansible/roles/wordpress-namespace/tasks/wp-cron.yml
@@ -25,7 +25,7 @@
                 serviceAccountName: wp-cron
                 containers:
                   - name: wp-cron
-                    image: "quay-its.epfl.ch/svc0041/wp-cron:2025-039"
+                    image: "quay-its.epfl.ch/svc0041/wp-cron:2025-040"
                     env:
                       - name: K8S_NAMESPACE
                         valueFrom:

--- a/docker/wp-cron/wordpresses.py
+++ b/docker/wp-cron/wordpresses.py
@@ -189,7 +189,7 @@ class WordpressSite:
                 name=self._wp['metadata']['name'],
                 body=[
                     {
-                        "op": "replace",
+                        "op": "add",
                         "path": "/status/wordpresssite",
                         "value": self._status_wordpresssite_struct()
                     }


### PR DESCRIPTION
As explained [here](https://datatracker.ietf.org/doc/html/rfc6902#section-4.1), for the `add` operator "If the target location specifies an object member that does exist, that member's value is replaced".
for the `replace` operator instead, [here](https://datatracker.ietf.org/doc/html/rfc6902#section-4.3), "The target location MUST exist for the operation to be successful"