### PR TITLE
[refactor] Move as much nginx config as possible into the template

### DIFF
--- a/docker/wordpress-nginx/nginx.tmpl
+++ b/docker/wordpress-nginx/nginx.tmpl
@@ -236,9 +236,24 @@ http {
 				{{ end }}
 			{{ else if and (not (empty $location.ConfigurationSnippet)) (not (empty $ing.Service)) }}
 
-{{/* This is the “main” Location object passed by the controller, and we use it to
-     render the main nginx config snippet (if there is one). */}}
+{{/* Render the nginx config for is the “main” Location object passed by the controller. */}}
 				location {{ $path }} {
+					include "/etc/nginx/template/wordpress_fastcgi.conf";
+
+					location = {{ $path }}wp-admin {
+						return 301 https://{{ buildServerName $server.Hostname }}{{ $path }}wp-admin/;
+					}
+
+					location ~ (wp-includes|wp-admin|wp-content/(plugins|mu-plugins|themes))/ {
+						rewrite .*/((wp-includes|wp-admin|wp-content/(plugins|mu-plugins|themes))/.*) /$1 break;
+						root /wp/;
+						location ~* \\.(ico|pdf|apng|avif|webp|jpg|jpeg|png|gif|svg)$ {
+							add_header Cache-Control "129600, public";
+							# rewrite is not inherited https://stackoverflow.com/a/32126596
+							rewrite .*/((wp-includes|wp-admin|wp-content/(plugins|mu-plugins|themes))/.*) /$1 break;
+						}
+					}
+
 					{{ $location.ConfigurationSnippet }}
 				}
 

--- a/docker/wordpress-nginx/nginx.tmpl
+++ b/docker/wordpress-nginx/nginx.tmpl
@@ -240,9 +240,11 @@ http {
 				location {{ $path }} {
 					include "/etc/nginx/template/wordpress_fastcgi.conf";
 
+					{{ if (not (contains $location.ConfigurationSnippet "/wp-admin {")) }}
 					location = {{ $path }}wp-admin {
 						return 301 https://{{ buildServerName $server.Hostname }}{{ $path }}wp-admin/;
 					}
+					{{ end }}
 
 					location ~ (wp-includes|wp-admin|wp-content/(plugins|mu-plugins|themes))/ {
 						rewrite .*/((wp-includes|wp-admin|wp-content/(plugins|mu-plugins|themes))/.*) /$1 break;


### PR DESCRIPTION
This uncouples the operator from nginx by this much, making it easier to implement site-independent changes in the serving discipline (such as [moving the goods from `/wp/6` to `/wp`](https://github.com/epfl-si/wp-ops/pull/683)).

See also: https://github.com/epfl-si/wp-operator/pull/59