### PR TITLE
[refactor] `WP_ABSPATH` into `docker/wordpress-nginx/nginx.tmpl`

### DIFF
--- a/docker/wordpress-nginx/nginx.tmpl
+++ b/docker/wordpress-nginx/nginx.tmpl
@@ -270,7 +270,6 @@ http {
 					}
 
 					{{ $location.ConfigurationSnippet }}
-                                        fastcgi_param WP_ABSPATH         /wp/;
 				}
 
 			{{ else }}

--- a/docker/wordpress-nginx/wordpress_fastcgi.conf
+++ b/docker/wordpress-nginx/wordpress_fastcgi.conf
@@ -1,4 +1,4 @@
-
+fastcgi_param WP_ABSPATH         /wp/;
 fastcgi_param SCRIPT_FILENAME /wp/nginx-entrypoint/nginx-entrypoint.php;
 fastcgi_param QUERY_STRING       $query_string;
 fastcgi_param REQUEST_METHOD     $request_method;


### PR DESCRIPTION
This doesn't have much impact, it just makes things neater.
