### PR TITLE
[fix] Switch from file to pipe lookup for Keybase secrets

### DIFF
--- a/ansible/roles/wordpress-builds/vars/s3-vars.yml
+++ b/ansible/roles/wordpress-builds/vars/s3-vars.yml
@@ -1,2 +1,2 @@
 s3_build_credentials: >-
-  {{ lookup('file', '/keybase/team/epfl_wp_test/s3-assets-credentials.sh') | regex_replace("^(.*?)=(.*)$", "\1: \2", multiline=True) | from_yaml }}
+  {{ lookup('pipe', 'keybase fs read /keybase/team/epfl_wp_test/s3-assets-credentials.sh') | regex_replace("^(.*?)=(.*)$", "\1: \2", multiline=True) | from_yaml }}

--- a/ansible/roles/wordpress-namespace/vars/cloudflare-vars.yml
+++ b/ansible/roles/wordpress-namespace/vars/cloudflare-vars.yml
@@ -1,4 +1,4 @@
-_cloudflare_secrets: "{{ lookup('file', '/keybase/team/epfl_wp_prod/cloudflare-secrets.yml') | from_yaml }}"
+_cloudflare_secrets: "{{ lookup('pipe', 'keybase fs read /keybase/team/epfl_wp_prod/cloudflare-secrets.yml') | from_yaml }}"
 cloudflare_api_url: "https://api.cloudflare.com/client/v4"
 cloudflare_api_zone_id: "{{ _cloudflare_secrets.API_ZONE_ID }}"
 cloudflare_api_tls_settings_token: "{{ _cloudflare_secrets.API_TLS_SETTINGS_TOKEN }}"

--- a/ansible/roles/wordpress-namespace/vars/monitoring-secrets.yml
+++ b/ansible/roles/wordpress-namespace/vars/monitoring-secrets.yml
@@ -1,5 +1,5 @@
 _keybase_team_wp: "{{ 'epfl_wp_prod' if inventory_namespace == 'svc0041p-wordpress' else 'epfl_wp_test' }}"
-_monitoring_secrets: "{{ lookup('file', '/keybase/team/{{ _keybase_team_wp }}/monitoring-internal.yml') | from_yaml }}"
+_monitoring_secrets: "{{ lookup('pipe', 'keybase fs read /keybase/team/{{ _keybase_team_wp }}/monitoring-internal.yml') | from_yaml }}"
 _telegram_alert: "{{ _monitoring_secrets.telegram_alert }}"
 
 telegram_bot_token: "{{ _telegram_alert.bot_token }}"

--- a/ansible/roles/wordpress-namespace/vars/report-uri-vars.yml
+++ b/ansible/roles/wordpress-namespace/vars/report-uri-vars.yml
@@ -1,5 +1,5 @@
 
-_report_uri_secrets: "{{ lookup('file', '/keybase/team/epfl_wp_prod/report-uri.yml') | from_yaml }}"
+_report_uri_secrets: "{{ lookup('pipe', 'keybase fs read /keybase/team/epfl_wp_prod/report-uri.yml') | from_yaml }}"
 _pull_robot_builder_secrets: "{{ _report_uri_secrets.quay.pull_robot_builder }}"
 _pull_robot_builder_credential: "{{ _pull_robot_builder_secrets.name }}:{{ _pull_robot_builder_secrets.token }}"
 report_uri_builder_pull_secret_config:

--- a/ansible/roles/wordpress-namespace/vars/s3-secrets-vars.yml
+++ b/ansible/roles/wordpress-namespace/vars/s3-secrets-vars.yml
@@ -16,8 +16,8 @@ eyaml_keys:
   priv: "/keybase/team/epfl_wp_test/eyaml-privkey.pem"
   pub: "{{ playbook_dir }}/eyaml/epfl_wp_test.pem"
 
-_epfl_migration_secrets: "{{ lookup('file', '/keybase/team/epfl_wp_prod/os3-s3-credentials.yaml') | from_yaml }}"
-_backup_secrets: "{{ lookup('file', '/keybase/team/epfl_wp_prod/os4-s3-credentials.yaml') | from_yaml }}"
+_epfl_migration_secrets: "{{ lookup('pipe', 'keybase fs read /keybase/team/epfl_wp_prod/os3-s3-credentials.yaml') | from_yaml }}"
+_backup_secrets: "{{ lookup('pipe', 'keybase fs read /keybase/team/epfl_wp_prod/os4-s3-credentials.yaml') | from_yaml }}"
 
 s3_epfl_migration_credentials:
   bucket_name: "{{ _epfl_migration_secrets.bucket_name }}"


### PR DESCRIPTION
Switch from file to pipe lookup for Keybase secrets because kbfs not working on Mac OS X