### PR TITLE
[fix] ConfigMap and label

### DIFF
--- a/ansible/roles/wordpress-namespace/tasks/mariadb.yml
+++ b/ansible/roles/wordpress-namespace/tasks/mariadb.yml
@@ -45,7 +45,7 @@
         name: "{{ mariadb_name }}-{{ '%02d' | format(item|int) }}"
         namespace: "{{ inventory_namespace }}"
         labels:
-          wpAutoallocate: 'true'
+          wp-auto-allocate: 'true'
       spec:
         storage:
           size: 1Gi

--- a/ansible/roles/wordpress-namespace/tasks/wp-operator.yml
+++ b/ansible/roles/wordpress-namespace/tasks/wp-operator.yml
@@ -22,6 +22,7 @@
         namespace: "{{ inventory_namespace }}"
       data:
         MARIADB-RESTORE: "{{ mariadb_name }}-restore"
+        MENU_API_HOST: "menu-api"
 
 - name: Pull secret for the OLM operator
   kubernetes.core.k8s:


### PR DESCRIPTION
- change the label for allocated mariadb
- add menu-api host into the wp-operator configmap